### PR TITLE
Upgrade dependencies to latest stable versions and migrate to Claude Opus 4.5

### DIFF
--- a/PROJECT_WORKFLOW.md
+++ b/PROJECT_WORKFLOW.md
@@ -59,7 +59,7 @@ Requirements:
 - Implements all abstract methods using Claude API calls
 - Uses tenacity for retry logic: @retry(stop=stop_after_attempt(3), wait=wait_exponential(min=1, max=10), retry=retry_if_exception_type(anthropic.APIError))
 - Tracks token usage: add usage_stats property returning dict with prompt_tokens, completion_tokens, total_tokens
-- Default model: claude-sonnet-4-20250514
+- Default model: claude-opus-4-5-20251101
 - Parse Claude responses as JSON, handle malformed responses gracefully
 
 Add integration test in tests/integration/test_claude_judge.py that:

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Create a `ragaliq.yaml` in your project root:
 
 ```yaml
 judge: claude
-model: claude-sonnet-4-20250514
+model: claude-opus-4-5-20251101
 evaluators:
   - faithfulness
   - relevance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,24 +34,24 @@ classifiers = [
 ]
 
 dependencies = [
-    "anthropic>=0.45.0",
-    "openai>=1.60.0",
-    "pydantic>=2.10",
-    "typer>=0.15.0",
-    "rich>=13.9",
+    "anthropic>=0.76.0",
+    "openai>=2.15.0",
+    "pydantic>=2.12",
+    "typer>=0.21.0",
+    "rich>=14.3",
     "jinja2>=3.1",
     "pyyaml>=6.0",
-    "httpx>=0.28",
-    "tenacity>=9.0",
+    "httpx>=0.28.1",
+    "tenacity>=9.1",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.3",
+    "pytest>=9.0",
     "pytest-asyncio>=0.25",
     "pytest-cov>=6.0",
-    "ruff>=0.9",
-    "mypy>=1.14",
+    "ruff>=0.14",
+    "mypy>=1.19",
     "pre-commit>=4.0",
 ]
 

--- a/tests/unit/test_models.py
+++ b/tests/unit/test_models.py
@@ -167,13 +167,13 @@ class TestEvaluationResult:
             score=0.8,
             passed=True,
             raw_response={
-                "model": "claude-sonnet-4-20250514",
+                "model": "claude-opus-4-5-20251101",
                 "tokens_used": 150,
                 "response_text": "...",
             },
         )
 
-        assert result.raw_response["model"] == "claude-sonnet-4-20250514"
+        assert result.raw_response["model"] == "claude-opus-4-5-20251101"
 
 
 class TestTestStatus:


### PR DESCRIPTION
## Summary

- **Anthropic SDK**: `>=0.45.0` → `>=0.76.0` (+31 versions) for Claude 4.5 model support
- **OpenAI SDK**: `>=1.60.0` → `>=2.15.0` (major version bump)
- **Core deps**: pydantic 2.12, typer 0.21, rich 14.3, httpx 0.28.1, tenacity 9.1
- **Dev deps**: pytest 9.0, ruff 0.14, mypy 1.19
- **Default model**: `claude-sonnet-4-20250514` → `claude-opus-4-5-20251101`

## Why Claude Opus 4.5?

RagaliQ uses LLM-as-Judge for RAG evaluation. Opus 4.5 provides:
1. Higher accuracy for nuanced claim verification and faithfulness assessment
2. Better multi-step reasoning for extract_claims → verify_claim pipeline  
3. Exclusive `effort` parameter for tuning evaluation thoroughness
4. 67% lower cost than previous Opus while maintaining flagship intelligence

## Files Changed

| File | Change |
|------|--------|
| `pyproject.toml` | Bump all dependency version constraints |
| `README.md` | Update example config model reference |
| `PROJECT_WORKFLOW.md` | Update default model in ClaudeJudge spec |
| `tests/unit/test_models.py` | Update test fixture model reference |

## Test plan

- [ ] Verify `make install` succeeds with new dependencies
- [ ] Run `make test` to confirm tests pass
- [ ] Run `make typecheck` to verify type compatibility
- [ ] Run `make lint` to check code style

🤖 Generated with [Claude Code](https://claude.com/claude-code)