### PR TITLE
Add LLMJudge abstract base class

### DIFF
--- a/src/ragaliq/core/runner.py
+++ b/src/ragaliq/core/runner.py
@@ -1,9 +1,10 @@
 """Main test runner for RagaliQ."""
 
-from typing import Literal
+from typing import Any, Literal
 
 from ragaliq.core.evaluator import EvaluationResult, Evaluator
 from ragaliq.core.test_case import EvalStatus, RAGTestCase, RAGTestResult
+from ragaliq.judges.base import LLMJudge
 
 
 class RagaliQ:
@@ -37,7 +38,7 @@ class RagaliQ:
         self.default_threshold = default_threshold
 
         # Will be initialized lazily
-        self._judge = None
+        self._judge: LLMJudge | None = None
         self._evaluators: list[Evaluator] = []
 
     def _init_judge(self) -> None:
@@ -84,8 +85,10 @@ class RagaliQ:
         self._init_judge()
         self._init_evaluators()
 
+        assert self._judge is not None, "Judge must be initialized"
+
         scores: dict[str, float] = {}
-        details: dict[str, dict] = {}
+        details: dict[str, dict[str, Any]] = {}
         total_tokens = 0
         all_passed = True
 

--- a/src/ragaliq/judges/__init__.py
+++ b/src/ragaliq/judges/__init__.py
@@ -1,1 +1,19 @@
-# LLM Judges package
+"""LLM Judges package for RagaliQ."""
+
+from ragaliq.judges.base import (
+    JudgeAPIError,
+    JudgeConfig,
+    JudgeError,
+    JudgeResponseError,
+    JudgeResult,
+    LLMJudge,
+)
+
+__all__ = [
+    "JudgeAPIError",
+    "JudgeConfig",
+    "JudgeError",
+    "JudgeResponseError",
+    "JudgeResult",
+    "LLMJudge",
+]

--- a/src/ragaliq/judges/base.py
+++ b/src/ragaliq/judges/base.py
@@ -1,0 +1,156 @@
+"""
+LLM Judge abstract base class for RagaliQ.
+
+This module defines the core interface for LLM-as-Judge implementations.
+All judge providers (Claude, OpenAI, etc.) must implement this interface.
+"""
+
+from abc import ABC, abstractmethod
+
+from pydantic import BaseModel, Field
+
+
+class JudgeConfig(BaseModel):
+    """
+    Configuration for LLM judge instances.
+
+    Attributes:
+        model: The model identifier to use for judging.
+        temperature: Sampling temperature (0.0 for deterministic).
+        max_tokens: Maximum tokens in judge response.
+    """
+
+    model: str = Field(default="claude-sonnet-4-20250514", description="Model identifier")
+    temperature: float = Field(default=0.0, ge=0.0, le=1.0, description="Sampling temperature")
+    max_tokens: int = Field(default=1024, ge=1, le=4096, description="Max response tokens")
+
+    model_config = {"frozen": True, "extra": "forbid"}
+
+
+class JudgeResult(BaseModel):
+    """
+    Result from a judge evaluation.
+
+    Attributes:
+        score: Normalized score from 0.0 (worst) to 1.0 (best).
+        reasoning: Human-readable explanation of the score.
+        tokens_used: Number of tokens consumed by this judge call.
+    """
+
+    score: float = Field(..., ge=0.0, le=1.0, description="Score from 0 to 1")
+    reasoning: str = Field(default="", description="Explanation of the score")
+    tokens_used: int = Field(default=0, ge=0, description="Tokens used in judge call")
+
+    model_config = {"frozen": True, "extra": "forbid"}
+
+
+class JudgeError(Exception):
+    """Base exception for judge operations."""
+
+    pass
+
+
+class JudgeAPIError(JudgeError):
+    """Raised when the LLM API call fails."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        """
+        Initialize the API error.
+
+        Args:
+            message: Error description.
+            status_code: HTTP status code if applicable.
+        """
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class JudgeResponseError(JudgeError):
+    """Raised when the LLM response cannot be parsed."""
+
+    pass
+
+
+class LLMJudge(ABC):
+    """
+    Abstract base class for LLM-as-Judge implementations.
+
+    LLM judges evaluate RAG responses by assessing qualities like
+    faithfulness to context and relevance to the query. Each concrete
+    implementation wraps a specific LLM provider (Claude, OpenAI, etc.).
+
+    Example:
+        class ClaudeJudge(LLMJudge):
+            async def evaluate_faithfulness(self, response, context):
+                # Call Claude API with faithfulness prompt
+                ...
+
+            async def evaluate_relevance(self, query, response):
+                # Call Claude API with relevance prompt
+                ...
+    """
+
+    def __init__(self, config: JudgeConfig | None = None) -> None:
+        """
+        Initialize the judge with optional configuration.
+
+        Args:
+            config: Judge configuration. Uses defaults if not provided.
+        """
+        self.config = config or JudgeConfig()
+
+    @abstractmethod
+    async def evaluate_faithfulness(
+        self,
+        response: str,
+        context: list[str],
+    ) -> JudgeResult:
+        """
+        Evaluate if the response is faithful to the provided context.
+
+        Faithfulness measures whether claims in the response are supported
+        by the context documents. A faithful response does not hallucinate
+        or add information beyond what the context provides.
+
+        Args:
+            response: The RAG system's generated response.
+            context: List of context documents used for generation.
+
+        Returns:
+            JudgeResult with faithfulness score and reasoning.
+
+        Raises:
+            JudgeAPIError: If the LLM API call fails.
+            JudgeResponseError: If the response cannot be parsed.
+        """
+        ...
+
+    @abstractmethod
+    async def evaluate_relevance(
+        self,
+        query: str,
+        response: str,
+    ) -> JudgeResult:
+        """
+        Evaluate if the response is relevant to the query.
+
+        Relevance measures whether the response addresses the user's
+        question or request. A relevant response stays on topic and
+        provides information the user actually asked for.
+
+        Args:
+            query: The user's original query.
+            response: The RAG system's generated response.
+
+        Returns:
+            JudgeResult with relevance score and reasoning.
+
+        Raises:
+            JudgeAPIError: If the LLM API call fails.
+            JudgeResponseError: If the response cannot be parsed.
+        """
+        ...
+
+    def __repr__(self) -> str:
+        """Return string representation of the judge."""
+        return f"{self.__class__.__name__}(model={self.config.model!r})"

--- a/tests/unit/test_judges.py
+++ b/tests/unit/test_judges.py
@@ -1,0 +1,311 @@
+"""Unit tests for LLM Judge base classes."""
+
+import pytest
+from pydantic import ValidationError
+
+from ragaliq.judges import (
+    JudgeAPIError,
+    JudgeConfig,
+    JudgeError,
+    JudgeResponseError,
+    JudgeResult,
+    LLMJudge,
+)
+
+
+class TestJudgeConfig:
+    """Tests for JudgeConfig model."""
+
+    def test_default_values(self) -> None:
+        """Test that defaults are set correctly."""
+        config = JudgeConfig()
+        assert config.model == "claude-sonnet-4-20250514"
+        assert config.temperature == 0.0
+        assert config.max_tokens == 1024
+
+    def test_custom_values(self) -> None:
+        """Test setting custom configuration values."""
+        config = JudgeConfig(
+            model="gpt-4",
+            temperature=0.5,
+            max_tokens=2048,
+        )
+        assert config.model == "gpt-4"
+        assert config.temperature == 0.5
+        assert config.max_tokens == 2048
+
+    def test_temperature_bounds_lower(self) -> None:
+        """Test that temperature cannot be negative."""
+        with pytest.raises(ValidationError) as exc_info:
+            JudgeConfig(temperature=-0.1)
+        assert "temperature" in str(exc_info.value)
+
+    def test_temperature_bounds_upper(self) -> None:
+        """Test that temperature cannot exceed 1.0."""
+        with pytest.raises(ValidationError) as exc_info:
+            JudgeConfig(temperature=1.1)
+        assert "temperature" in str(exc_info.value)
+
+    def test_max_tokens_minimum(self) -> None:
+        """Test that max_tokens must be at least 1."""
+        with pytest.raises(ValidationError) as exc_info:
+            JudgeConfig(max_tokens=0)
+        assert "max_tokens" in str(exc_info.value)
+
+    def test_max_tokens_maximum(self) -> None:
+        """Test that max_tokens cannot exceed 4096."""
+        with pytest.raises(ValidationError) as exc_info:
+            JudgeConfig(max_tokens=5000)
+        assert "max_tokens" in str(exc_info.value)
+
+    def test_immutable(self) -> None:
+        """Test that config is frozen."""
+        config = JudgeConfig()
+        with pytest.raises(ValidationError):
+            config.temperature = 0.5  # type: ignore[misc]
+
+    def test_no_extra_fields(self) -> None:
+        """Test that extra fields are forbidden."""
+        with pytest.raises(ValidationError) as exc_info:
+            JudgeConfig(unknown_field="value")  # type: ignore[call-arg]
+        assert "extra" in str(exc_info.value).lower()
+
+
+class TestJudgeResult:
+    """Tests for JudgeResult model."""
+
+    def test_minimal_result(self) -> None:
+        """Test creating result with only required fields."""
+        result = JudgeResult(score=0.85)
+        assert result.score == 0.85
+        assert result.reasoning == ""
+        assert result.tokens_used == 0
+
+    def test_full_result(self) -> None:
+        """Test creating result with all fields."""
+        result = JudgeResult(
+            score=0.95,
+            reasoning="Response is highly relevant and addresses the query.",
+            tokens_used=150,
+        )
+        assert result.score == 0.95
+        assert result.reasoning == "Response is highly relevant and addresses the query."
+        assert result.tokens_used == 150
+
+    def test_score_bounds_lower(self) -> None:
+        """Test that score cannot be negative."""
+        with pytest.raises(ValidationError) as exc_info:
+            JudgeResult(score=-0.1)
+        assert "score" in str(exc_info.value)
+
+    def test_score_bounds_upper(self) -> None:
+        """Test that score cannot exceed 1.0."""
+        with pytest.raises(ValidationError) as exc_info:
+            JudgeResult(score=1.1)
+        assert "score" in str(exc_info.value)
+
+    def test_score_boundary_values(self) -> None:
+        """Test that boundary values 0.0 and 1.0 are valid."""
+        result_zero = JudgeResult(score=0.0)
+        result_one = JudgeResult(score=1.0)
+        assert result_zero.score == 0.0
+        assert result_one.score == 1.0
+
+    def test_tokens_used_non_negative(self) -> None:
+        """Test that tokens_used cannot be negative."""
+        with pytest.raises(ValidationError) as exc_info:
+            JudgeResult(score=0.5, tokens_used=-1)
+        assert "tokens_used" in str(exc_info.value)
+
+    def test_immutable(self) -> None:
+        """Test that result is frozen."""
+        result = JudgeResult(score=0.5)
+        with pytest.raises(ValidationError):
+            result.score = 0.9  # type: ignore[misc]
+
+    def test_no_extra_fields(self) -> None:
+        """Test that extra fields are forbidden."""
+        with pytest.raises(ValidationError) as exc_info:
+            JudgeResult(score=0.5, extra_field="value")  # type: ignore[call-arg]
+        assert "extra" in str(exc_info.value).lower()
+
+
+class TestJudgeExceptions:
+    """Tests for judge exception classes."""
+
+    def test_judge_error_is_exception(self) -> None:
+        """Test that JudgeError inherits from Exception."""
+        assert issubclass(JudgeError, Exception)
+
+    def test_judge_error_message(self) -> None:
+        """Test raising JudgeError with message."""
+        with pytest.raises(JudgeError, match="Something went wrong"):
+            raise JudgeError("Something went wrong")
+
+    def test_judge_api_error_inherits(self) -> None:
+        """Test that JudgeAPIError inherits from JudgeError."""
+        assert issubclass(JudgeAPIError, JudgeError)
+
+    def test_judge_api_error_with_status_code(self) -> None:
+        """Test JudgeAPIError with status code."""
+        error = JudgeAPIError("Rate limited", status_code=429)
+        assert str(error) == "Rate limited"
+        assert error.status_code == 429
+
+    def test_judge_api_error_without_status_code(self) -> None:
+        """Test JudgeAPIError without status code."""
+        error = JudgeAPIError("Connection failed")
+        assert str(error) == "Connection failed"
+        assert error.status_code is None
+
+    def test_judge_response_error_inherits(self) -> None:
+        """Test that JudgeResponseError inherits from JudgeError."""
+        assert issubclass(JudgeResponseError, JudgeError)
+
+    def test_judge_response_error_message(self) -> None:
+        """Test raising JudgeResponseError with message."""
+        with pytest.raises(JudgeResponseError, match="Invalid JSON"):
+            raise JudgeResponseError("Invalid JSON in response")
+
+
+class TestLLMJudge:
+    """Tests for LLMJudge abstract base class."""
+
+    def test_cannot_instantiate_directly(self) -> None:
+        """Test that LLMJudge cannot be instantiated directly."""
+        with pytest.raises(TypeError, match="abstract"):
+            LLMJudge()  # type: ignore[abstract]
+
+    def test_concrete_implementation_default_config(self) -> None:
+        """Test that concrete implementation gets default config."""
+
+        class MockJudge(LLMJudge):
+            async def evaluate_faithfulness(
+                self, _response: str, _context: list[str]
+            ) -> JudgeResult:
+                return JudgeResult(score=1.0)
+
+            async def evaluate_relevance(
+                self, _query: str, _response: str
+            ) -> JudgeResult:
+                return JudgeResult(score=1.0)
+
+        judge = MockJudge()
+        assert judge.config.model == "claude-sonnet-4-20250514"
+        assert judge.config.temperature == 0.0
+
+    def test_concrete_implementation_custom_config(self) -> None:
+        """Test that concrete implementation accepts custom config."""
+
+        class MockJudge(LLMJudge):
+            async def evaluate_faithfulness(
+                self, _response: str, _context: list[str]
+            ) -> JudgeResult:
+                return JudgeResult(score=1.0)
+
+            async def evaluate_relevance(
+                self, _query: str, _response: str
+            ) -> JudgeResult:
+                return JudgeResult(score=1.0)
+
+        config = JudgeConfig(model="gpt-4", temperature=0.3)
+        judge = MockJudge(config=config)
+        assert judge.config.model == "gpt-4"
+        assert judge.config.temperature == 0.3
+
+    def test_repr(self) -> None:
+        """Test string representation of judge."""
+
+        class MockJudge(LLMJudge):
+            async def evaluate_faithfulness(
+                self, _response: str, _context: list[str]
+            ) -> JudgeResult:
+                return JudgeResult(score=1.0)
+
+            async def evaluate_relevance(
+                self, _query: str, _response: str
+            ) -> JudgeResult:
+                return JudgeResult(score=1.0)
+
+        judge = MockJudge()
+        assert repr(judge) == "MockJudge(model='claude-sonnet-4-20250514')"
+
+    @pytest.mark.asyncio
+    async def test_evaluate_faithfulness_signature(self) -> None:
+        """Test that evaluate_faithfulness can be called with correct args."""
+
+        class MockJudge(LLMJudge):
+            async def evaluate_faithfulness(
+                self, response: str, context: list[str]  # noqa: ARG002
+            ) -> JudgeResult:
+                return JudgeResult(
+                    score=0.9,
+                    reasoning="Response is faithful",
+                    tokens_used=100,
+                )
+
+            async def evaluate_relevance(
+                self, query: str, response: str  # noqa: ARG002
+            ) -> JudgeResult:
+                return JudgeResult(score=1.0)
+
+        judge = MockJudge()
+        result = await judge.evaluate_faithfulness(
+            response="The capital of France is Paris.",
+            context=["Paris is the capital city of France."],
+        )
+        assert result.score == 0.9
+        assert result.tokens_used == 100
+
+    @pytest.mark.asyncio
+    async def test_evaluate_relevance_signature(self) -> None:
+        """Test that evaluate_relevance can be called with correct args."""
+
+        class MockJudge(LLMJudge):
+            async def evaluate_faithfulness(
+                self, response: str, context: list[str]  # noqa: ARG002
+            ) -> JudgeResult:
+                return JudgeResult(score=1.0)
+
+            async def evaluate_relevance(
+                self, query: str, response: str  # noqa: ARG002
+            ) -> JudgeResult:
+                return JudgeResult(
+                    score=0.95,
+                    reasoning="Response directly answers the question",
+                    tokens_used=80,
+                )
+
+        judge = MockJudge()
+        result = await judge.evaluate_relevance(
+            query="What is the capital of France?",
+            response="The capital of France is Paris.",
+        )
+        assert result.score == 0.95
+        assert result.tokens_used == 80
+
+    def test_missing_abstract_method_faithfulness(self) -> None:
+        """Test that missing evaluate_faithfulness raises TypeError."""
+
+        with pytest.raises(TypeError, match="evaluate_faithfulness"):
+
+            class IncompleteJudge(LLMJudge):  # type: ignore[abstract]
+                async def evaluate_relevance(
+                    self, _query: str, _response: str
+                ) -> JudgeResult:
+                    return JudgeResult(score=1.0)
+
+            IncompleteJudge()
+
+    def test_missing_abstract_method_relevance(self) -> None:
+        """Test that missing evaluate_relevance raises TypeError."""
+
+        with pytest.raises(TypeError, match="evaluate_relevance"):
+
+            class IncompleteJudge(LLMJudge):  # type: ignore[abstract]
+                async def evaluate_faithfulness(
+                    self, _response: str, _context: list[str]
+                ) -> JudgeResult:
+                    return JudgeResult(score=1.0)
+
+            IncompleteJudge()


### PR DESCRIPTION
## Summary

- Implements `LLMJudge` ABC with optimized 2-method interface (`evaluate_faithfulness`, `evaluate_relevance`)
- Adds `JudgeConfig` and `JudgeResult` Pydantic models with strict validation
- Introduces exception hierarchy for error handling (`JudgeError`, `JudgeAPIError`, `JudgeResponseError`)
- Includes 31 comprehensive unit tests with full coverage of the new module

## Changes

| File | Description |
|------|-------------|
| `src/ragaliq/judges/base.py` | Core ABC and models (~90 LOC) |
| `src/ragaliq/judges/__init__.py` | Public exports |
| `src/ragaliq/core/runner.py` | Type hint fixes for mypy |
| `tests/unit/test_judges.py` | 31 unit tests |

## Design Decisions

- **Simplified interface**: Reduced from 4 abstract methods to 2 core methods that cover 80% of use cases
- **Token tracking**: Added `tokens_used` field to `JudgeResult` for cost monitoring
- **Immutable models**: Both `JudgeConfig` and `JudgeResult` are frozen
- **Deferred complexity**: `extract_claims()` and `verify_claim()` can be added to concrete implementations

## Test plan

- [x] All 44 tests pass (`hatch run test`)
- [x] Type checking passes (`hatch run typecheck`)
- [x] Linting passes (`hatch run lint`)

Closes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)