### PR TITLE
Add ClaudeJudge implementation with Anthropic SDK

### DIFF
--- a/src/ragaliq/judges/__init__.py
+++ b/src/ragaliq/judges/__init__.py
@@ -8,8 +8,10 @@ from ragaliq.judges.base import (
     JudgeResult,
     LLMJudge,
 )
+from ragaliq.judges.claude import ClaudeJudge
 
 __all__ = [
+    "ClaudeJudge",
     "JudgeAPIError",
     "JudgeConfig",
     "JudgeError",

--- a/src/ragaliq/judges/claude.py
+++ b/src/ragaliq/judges/claude.py
@@ -1,0 +1,373 @@
+"""
+ClaudeJudge implementation for RagaliQ.
+
+This module provides an LLM-as-Judge implementation using Anthropic's Claude API.
+It evaluates RAG responses for faithfulness and relevance using structured prompts.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import TYPE_CHECKING, Any
+
+from anthropic import APIConnectionError, APIStatusError, AsyncAnthropic
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+from ragaliq.judges.base import (
+    JudgeAPIError,
+    JudgeConfig,
+    JudgeResponseError,
+    JudgeResult,
+    LLMJudge,
+)
+
+if TYPE_CHECKING:
+    from anthropic.types import Message
+
+
+class ClaudeJudge(LLMJudge):
+    """
+    LLM-as-Judge implementation using Anthropic's Claude API.
+
+    ClaudeJudge evaluates RAG responses by sending structured prompts to Claude
+    and parsing JSON responses containing scores and reasoning.
+
+    Example:
+        judge = ClaudeJudge()
+        result = await judge.evaluate_faithfulness(
+            response="Paris is the capital of France.",
+            context=["France is a country in Europe. Its capital is Paris."]
+        )
+        print(f"Faithfulness: {result.score}")
+
+    Attributes:
+        config: Judge configuration (model, temperature, max_tokens).
+        client: Anthropic async client instance.
+    """
+
+    def __init__(
+        self,
+        config: JudgeConfig | None = None,
+        *,
+        api_key: str | None = None,
+    ) -> None:
+        """
+        Initialize ClaudeJudge with optional configuration.
+
+        Args:
+            config: Judge configuration. Uses defaults if not provided.
+            api_key: Anthropic API key. Falls back to ANTHROPIC_API_KEY env var.
+
+        Raises:
+            ValueError: If no API key is provided or found in environment.
+        """
+        super().__init__(config)
+
+        # Resolve API key: explicit > environment
+        resolved_key = api_key or os.getenv("ANTHROPIC_API_KEY")
+        if not resolved_key:
+            raise ValueError(
+                "Anthropic API key required. Provide via api_key parameter "
+                "or set ANTHROPIC_API_KEY environment variable."
+            )
+
+        self._client = AsyncAnthropic(api_key=resolved_key)
+
+    @retry(
+        retry=retry_if_exception_type(APIConnectionError),
+        stop=stop_after_attempt(3),
+        wait=wait_exponential(multiplier=1, min=1, max=10),
+        reraise=True,
+    )
+    async def _call_claude(
+        self,
+        system_prompt: str,
+        user_prompt: str,
+    ) -> tuple[str, int]:
+        """
+        Make a retry-enabled call to Claude API.
+
+        Uses tenacity for automatic retries on connection errors with
+        exponential backoff (1s, 2s, 4s max 10s between attempts).
+
+        Args:
+            system_prompt: System message defining Claude's role.
+            user_prompt: User message with the evaluation task.
+
+        Returns:
+            Tuple of (response_text, tokens_used).
+
+        Raises:
+            JudgeAPIError: If API call fails after retries.
+        """
+        try:
+            response: Message = await self._client.messages.create(
+                model=self.config.model,
+                max_tokens=self.config.max_tokens,
+                temperature=self.config.temperature,
+                messages=[{"role": "user", "content": user_prompt}],
+                system=system_prompt,
+            )
+
+            # Extract text content from response
+            content = response.content[0]
+            if content.type != "text":
+                raise JudgeResponseError(
+                    f"Expected text response, got {content.type}"
+                )
+
+            # Calculate total tokens used
+            tokens_used = response.usage.input_tokens + response.usage.output_tokens
+
+            return content.text, tokens_used
+
+        except APIStatusError as e:
+            # Map Anthropic status errors to our exception hierarchy
+            raise JudgeAPIError(
+                f"Claude API error: {e.message}",
+                status_code=e.status_code,
+            ) from e
+        except APIConnectionError:
+            # Let tenacity handle retries; if exhausted, reraise
+            raise
+
+    def _parse_json_response(self, text: str) -> dict[str, Any]:
+        """
+        Parse JSON from Claude's response.
+
+        Handles cases where Claude wraps JSON in markdown code blocks.
+
+        Args:
+            text: Raw response text from Claude.
+
+        Returns:
+            Parsed JSON as dictionary.
+
+        Raises:
+            JudgeResponseError: If JSON parsing fails.
+        """
+        # Strip markdown code blocks if present
+        cleaned = text.strip()
+        if cleaned.startswith("```"):
+            # Remove opening fence (with optional language tag)
+            lines = cleaned.split("\n")
+            lines = lines[1:]  # Remove ```json or ```
+            # Remove closing fence
+            if lines and lines[-1].strip() == "```":
+                lines = lines[:-1]
+            cleaned = "\n".join(lines)
+
+        try:
+            result: dict[str, Any] = json.loads(cleaned)
+            return result
+        except json.JSONDecodeError as e:
+            raise JudgeResponseError(
+                f"Failed to parse JSON response: {e}. Raw text: {text[:200]}"
+            ) from e
+
+    def _build_faithfulness_prompt(
+        self,
+        response: str,
+        context: list[str],
+    ) -> tuple[str, str]:
+        """
+        Build prompts for faithfulness evaluation.
+
+        Args:
+            response: The RAG response to evaluate.
+            context: Context documents used for generation.
+
+        Returns:
+            Tuple of (system_prompt, user_prompt).
+        """
+        system_prompt = """You are an expert evaluator assessing whether a response is faithful to the provided context.
+
+Faithfulness means:
+- Every claim in the response is supported by the context
+- No information is fabricated or hallucinated
+- No claims go beyond what the context states
+
+Score criteria:
+- 1.0: All claims are fully supported by context
+- 0.7-0.9: Most claims supported, minor unsupported details
+- 0.4-0.6: Mixed - some claims supported, others not
+- 0.1-0.3: Most claims unsupported by context
+- 0.0: Response contradicts or is completely unrelated to context
+
+Respond ONLY with valid JSON in this exact format:
+{"score": <float 0.0-1.0>, "reasoning": "<brief explanation>"}"""
+
+        # Format context documents with clear separation
+        context_text = "\n\n---\n\n".join(
+            f"Document {i + 1}:\n{doc}" for i, doc in enumerate(context)
+        )
+
+        user_prompt = f"""Evaluate the faithfulness of this response to the context.
+
+CONTEXT:
+{context_text}
+
+RESPONSE TO EVALUATE:
+{response}
+
+Return JSON with score (0.0-1.0) and reasoning."""
+
+        return system_prompt, user_prompt
+
+    def _build_relevance_prompt(
+        self,
+        query: str,
+        response: str,
+    ) -> tuple[str, str]:
+        """
+        Build prompts for relevance evaluation.
+
+        Args:
+            query: The user's original query.
+            response: The RAG response to evaluate.
+
+        Returns:
+            Tuple of (system_prompt, user_prompt).
+        """
+        system_prompt = """You are an expert evaluator assessing whether a response is relevant to the user's query.
+
+Relevance means:
+- The response directly addresses what the user asked
+- The information provided is useful for answering the query
+- The response stays on topic and doesn't include irrelevant information
+
+Score criteria:
+- 1.0: Response perfectly addresses the query
+- 0.7-0.9: Response mostly addresses query with minor gaps
+- 0.4-0.6: Response partially addresses query or includes irrelevant info
+- 0.1-0.3: Response barely addresses the query
+- 0.0: Response is completely irrelevant to the query
+
+Respond ONLY with valid JSON in this exact format:
+{"score": <float 0.0-1.0>, "reasoning": "<brief explanation>"}"""
+
+        user_prompt = f"""Evaluate the relevance of this response to the query.
+
+QUERY:
+{query}
+
+RESPONSE TO EVALUATE:
+{response}
+
+Return JSON with score (0.0-1.0) and reasoning."""
+
+        return system_prompt, user_prompt
+
+    async def evaluate_faithfulness(
+        self,
+        response: str,
+        context: list[str],
+    ) -> JudgeResult:
+        """
+        Evaluate if the response is faithful to the provided context.
+
+        Uses Claude to analyze whether claims in the response are
+        supported by the context documents.
+
+        Args:
+            response: The RAG system's generated response.
+            context: List of context documents used for generation.
+
+        Returns:
+            JudgeResult with faithfulness score (0.0-1.0) and reasoning.
+
+        Raises:
+            JudgeAPIError: If Claude API call fails.
+            JudgeResponseError: If response parsing fails.
+        """
+        if not context:
+            # Edge case: no context means any claim is unsupported
+            return JudgeResult(
+                score=0.0,
+                reasoning="No context provided; faithfulness cannot be assessed.",
+                tokens_used=0,
+            )
+
+        system_prompt, user_prompt = self._build_faithfulness_prompt(
+            response, context
+        )
+
+        try:
+            raw_response, tokens_used = await self._call_claude(
+                system_prompt, user_prompt
+            )
+        except APIConnectionError as e:
+            raise JudgeAPIError(f"Connection to Claude API failed: {e}") from e
+
+        parsed = self._parse_json_response(raw_response)
+
+        # Validate required fields
+        if "score" not in parsed:
+            raise JudgeResponseError(
+                f"Response missing 'score' field: {parsed}"
+            )
+
+        score = float(parsed["score"])
+        # Clamp score to valid range (defensive)
+        score = max(0.0, min(1.0, score))
+
+        return JudgeResult(
+            score=score,
+            reasoning=parsed.get("reasoning", ""),
+            tokens_used=tokens_used,
+        )
+
+    async def evaluate_relevance(
+        self,
+        query: str,
+        response: str,
+    ) -> JudgeResult:
+        """
+        Evaluate if the response is relevant to the query.
+
+        Uses Claude to analyze whether the response addresses
+        the user's question effectively.
+
+        Args:
+            query: The user's original query.
+            response: The RAG system's generated response.
+
+        Returns:
+            JudgeResult with relevance score (0.0-1.0) and reasoning.
+
+        Raises:
+            JudgeAPIError: If Claude API call fails.
+            JudgeResponseError: If response parsing fails.
+        """
+        system_prompt, user_prompt = self._build_relevance_prompt(query, response)
+
+        try:
+            raw_response, tokens_used = await self._call_claude(
+                system_prompt, user_prompt
+            )
+        except APIConnectionError as e:
+            raise JudgeAPIError(f"Connection to Claude API failed: {e}") from e
+
+        parsed = self._parse_json_response(raw_response)
+
+        # Validate required fields
+        if "score" not in parsed:
+            raise JudgeResponseError(
+                f"Response missing 'score' field: {parsed}"
+            )
+
+        score = float(parsed["score"])
+        # Clamp score to valid range (defensive)
+        score = max(0.0, min(1.0, score))
+
+        return JudgeResult(
+            score=score,
+            reasoning=parsed.get("reasoning", ""),
+            tokens_used=tokens_used,
+        )

--- a/tests/unit/test_claude_judge.py
+++ b/tests/unit/test_claude_judge.py
@@ -1,0 +1,483 @@
+"""Unit tests for ClaudeJudge implementation."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from anthropic import APIConnectionError, APIStatusError
+
+from ragaliq.judges import (
+    ClaudeJudge,
+    JudgeAPIError,
+    JudgeConfig,
+    JudgeResponseError,
+    JudgeResult,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
+
+
+@pytest.fixture
+def mock_anthropic_client() -> Generator[MagicMock]:
+    """Create a mock Anthropic client."""
+    with patch("ragaliq.judges.claude.AsyncAnthropic") as mock_class:
+        mock_client = MagicMock()
+        mock_class.return_value = mock_client
+        yield mock_client
+
+
+@pytest.fixture
+def mock_response() -> MagicMock:
+    """Create a mock Claude API response."""
+    response = MagicMock()
+    response.content = [MagicMock(type="text", text='{"score": 0.85, "reasoning": "Test"}')]
+    response.usage.input_tokens = 100
+    response.usage.output_tokens = 50
+    return response
+
+
+@pytest.mark.usefixtures("mock_anthropic_client")
+class TestClaudeJudgeInit:
+    """Tests for ClaudeJudge initialization."""
+
+    def test_init_with_api_key(self) -> None:
+        """Test initialization with explicit API key."""
+        judge = ClaudeJudge(api_key="test-key")
+        assert judge.config.model == "claude-sonnet-4-20250514"
+        assert judge.config.temperature == 0.0
+
+    def test_init_with_env_var(self) -> None:
+        """Test initialization with environment variable."""
+        with patch.dict("os.environ", {"ANTHROPIC_API_KEY": "env-key"}):
+            judge = ClaudeJudge()
+            assert judge.config.model == "claude-sonnet-4-20250514"
+
+    def test_init_no_api_key_raises(self) -> None:
+        """Test that missing API key raises ValueError."""
+        with (
+            patch.dict("os.environ", {}, clear=True),
+            patch("ragaliq.judges.claude.AsyncAnthropic"),
+            pytest.raises(ValueError, match="Anthropic API key required"),
+        ):
+            # Ensure ANTHROPIC_API_KEY is not set
+            import os
+
+            os.environ.pop("ANTHROPIC_API_KEY", None)
+            ClaudeJudge()
+
+    def test_init_with_custom_config(self) -> None:
+        """Test initialization with custom configuration."""
+        config = JudgeConfig(model="claude-opus-4-20250514", temperature=0.3, max_tokens=2048)
+        judge = ClaudeJudge(config=config, api_key="test-key")
+        assert judge.config.model == "claude-opus-4-20250514"
+        assert judge.config.temperature == 0.3
+        assert judge.config.max_tokens == 2048
+
+    def test_repr(self) -> None:
+        """Test string representation."""
+        judge = ClaudeJudge(api_key="test-key")
+        assert repr(judge) == "ClaudeJudge(model='claude-sonnet-4-20250514')"
+
+
+class TestClaudeJudgeFaithfulness:
+    """Tests for evaluate_faithfulness method."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_faithfulness_success(
+        self,
+        mock_anthropic_client: MagicMock,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test successful faithfulness evaluation."""
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        result = await judge.evaluate_faithfulness(
+            response="Paris is the capital of France.",
+            context=["France is a country in Europe. Its capital is Paris."],
+        )
+
+        assert isinstance(result, JudgeResult)
+        assert result.score == 0.85
+        assert result.reasoning == "Test"
+        assert result.tokens_used == 150  # 100 + 50
+
+    @pytest.mark.asyncio
+    @pytest.mark.usefixtures("mock_anthropic_client")
+    async def test_evaluate_faithfulness_empty_context(self) -> None:
+        """Test faithfulness with empty context returns 0.0."""
+        judge = ClaudeJudge(api_key="test-key")
+        result = await judge.evaluate_faithfulness(
+            response="Any response",
+            context=[],
+        )
+
+        assert result.score == 0.0
+        assert "No context provided" in result.reasoning
+        assert result.tokens_used == 0
+
+    @pytest.mark.asyncio
+    async def test_evaluate_faithfulness_multiple_context_docs(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test faithfulness with multiple context documents."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(type="text", text='{"score": 0.95, "reasoning": "All claims supported"}')
+        ]
+        mock_response.usage.input_tokens = 200
+        mock_response.usage.output_tokens = 60
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        result = await judge.evaluate_faithfulness(
+            response="Paris is in France. It has the Eiffel Tower.",
+            context=[
+                "Paris is the capital of France.",
+                "The Eiffel Tower is located in Paris.",
+            ],
+        )
+
+        assert result.score == 0.95
+        assert result.tokens_used == 260
+
+    @pytest.mark.asyncio
+    async def test_evaluate_faithfulness_score_clamping(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test that out-of-range scores are clamped."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(type="text", text='{"score": 1.5, "reasoning": "Too high"}')
+        ]
+        mock_response.usage.input_tokens = 100
+        mock_response.usage.output_tokens = 50
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        result = await judge.evaluate_faithfulness(
+            response="Test",
+            context=["Test context"],
+        )
+
+        assert result.score == 1.0  # Clamped to max
+
+    @pytest.mark.asyncio
+    async def test_evaluate_faithfulness_negative_score_clamping(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test that negative scores are clamped to 0.0."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(type="text", text='{"score": -0.5, "reasoning": "Negative"}')
+        ]
+        mock_response.usage.input_tokens = 100
+        mock_response.usage.output_tokens = 50
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        result = await judge.evaluate_faithfulness(
+            response="Test",
+            context=["Test context"],
+        )
+
+        assert result.score == 0.0  # Clamped to min
+
+
+class TestClaudeJudgeRelevance:
+    """Tests for evaluate_relevance method."""
+
+    @pytest.mark.asyncio
+    async def test_evaluate_relevance_success(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test successful relevance evaluation."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                type="text", text='{"score": 0.92, "reasoning": "Directly answers the question"}'
+            )
+        ]
+        mock_response.usage.input_tokens = 80
+        mock_response.usage.output_tokens = 40
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        result = await judge.evaluate_relevance(
+            query="What is the capital of France?",
+            response="The capital of France is Paris.",
+        )
+
+        assert isinstance(result, JudgeResult)
+        assert result.score == 0.92
+        assert "answers" in result.reasoning
+        assert result.tokens_used == 120
+
+    @pytest.mark.asyncio
+    async def test_evaluate_relevance_irrelevant(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test relevance evaluation for irrelevant response."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                type="text",
+                text='{"score": 0.1, "reasoning": "Response does not address the query"}',
+            )
+        ]
+        mock_response.usage.input_tokens = 80
+        mock_response.usage.output_tokens = 40
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        result = await judge.evaluate_relevance(
+            query="What is the capital of France?",
+            response="The weather is nice today.",
+        )
+
+        assert result.score == 0.1
+
+
+class TestClaudeJudgeErrorHandling:
+    """Tests for error handling in ClaudeJudge."""
+
+    @pytest.mark.asyncio
+    async def test_api_status_error(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test handling of API status errors."""
+        error_response = MagicMock()
+        error_response.status_code = 429
+        mock_anthropic_client.messages.create = AsyncMock(
+            side_effect=APIStatusError(
+                message="Rate limit exceeded",
+                response=error_response,
+                body={"error": "rate_limited"},
+            )
+        )
+
+        judge = ClaudeJudge(api_key="test-key")
+        with pytest.raises(JudgeAPIError) as exc_info:
+            await judge.evaluate_faithfulness(
+                response="Test",
+                context=["Context"],
+            )
+
+        assert exc_info.value.status_code == 429
+        assert "Rate limit" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_connection_error_after_retries(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test that connection errors are retried then raised."""
+        mock_anthropic_client.messages.create = AsyncMock(
+            side_effect=APIConnectionError(request=MagicMock())
+        )
+
+        judge = ClaudeJudge(api_key="test-key")
+        with pytest.raises(JudgeAPIError, match="Connection to Claude API failed"):
+            await judge.evaluate_faithfulness(
+                response="Test",
+                context=["Context"],
+            )
+
+    @pytest.mark.asyncio
+    async def test_invalid_json_response(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test handling of invalid JSON in response."""
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(type="text", text="Not valid JSON")]
+        mock_response.usage.input_tokens = 100
+        mock_response.usage.output_tokens = 50
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        with pytest.raises(JudgeResponseError, match="Failed to parse JSON"):
+            await judge.evaluate_faithfulness(
+                response="Test",
+                context=["Context"],
+            )
+
+    @pytest.mark.asyncio
+    async def test_missing_score_field(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test handling of response missing score field."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(type="text", text='{"reasoning": "No score provided"}')
+        ]
+        mock_response.usage.input_tokens = 100
+        mock_response.usage.output_tokens = 50
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        with pytest.raises(JudgeResponseError, match="missing 'score' field"):
+            await judge.evaluate_faithfulness(
+                response="Test",
+                context=["Context"],
+            )
+
+    @pytest.mark.asyncio
+    async def test_non_text_response_type(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test handling of non-text response type."""
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(type="tool_use", text=None)]
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        with pytest.raises(JudgeResponseError, match="Expected text response"):
+            await judge.evaluate_faithfulness(
+                response="Test",
+                context=["Context"],
+            )
+
+
+class TestClaudeJudgeJsonParsing:
+    """Tests for JSON parsing edge cases."""
+
+    @pytest.mark.asyncio
+    async def test_json_in_markdown_code_block(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test parsing JSON wrapped in markdown code blocks."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                type="text",
+                text='```json\n{"score": 0.75, "reasoning": "Wrapped in markdown"}\n```',
+            )
+        ]
+        mock_response.usage.input_tokens = 100
+        mock_response.usage.output_tokens = 50
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        result = await judge.evaluate_faithfulness(
+            response="Test",
+            context=["Context"],
+        )
+
+        assert result.score == 0.75
+        assert result.reasoning == "Wrapped in markdown"
+
+    @pytest.mark.asyncio
+    async def test_json_with_whitespace(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test parsing JSON with surrounding whitespace."""
+        mock_response = MagicMock()
+        mock_response.content = [
+            MagicMock(
+                type="text", text='  \n  {"score": 0.80, "reasoning": "With whitespace"}  \n  '
+            )
+        ]
+        mock_response.usage.input_tokens = 100
+        mock_response.usage.output_tokens = 50
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        result = await judge.evaluate_faithfulness(
+            response="Test",
+            context=["Context"],
+        )
+
+        assert result.score == 0.80
+
+    @pytest.mark.asyncio
+    async def test_missing_reasoning_field(
+        self,
+        mock_anthropic_client: MagicMock,
+    ) -> None:
+        """Test that missing reasoning field defaults to empty string."""
+        mock_response = MagicMock()
+        mock_response.content = [MagicMock(type="text", text='{"score": 0.6}')]
+        mock_response.usage.input_tokens = 100
+        mock_response.usage.output_tokens = 50
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        judge = ClaudeJudge(api_key="test-key")
+        result = await judge.evaluate_faithfulness(
+            response="Test",
+            context=["Context"],
+        )
+
+        assert result.score == 0.6
+        assert result.reasoning == ""
+
+
+@pytest.mark.usefixtures("mock_anthropic_client")
+class TestClaudeJudgePromptBuilding:
+    """Tests for prompt construction."""
+
+    def test_faithfulness_prompt_contains_context(self) -> None:
+        """Test that faithfulness prompt includes context documents."""
+        judge = ClaudeJudge(api_key="test-key")
+        system_prompt, user_prompt = judge._build_faithfulness_prompt(
+            response="Test response",
+            context=["Doc 1", "Doc 2"],
+        )
+
+        assert "Document 1" in user_prompt
+        assert "Doc 1" in user_prompt
+        assert "Document 2" in user_prompt
+        assert "Doc 2" in user_prompt
+        assert "Test response" in user_prompt
+        assert "faithfulness" in system_prompt.lower()
+
+    def test_relevance_prompt_contains_query(self) -> None:
+        """Test that relevance prompt includes query and response."""
+        judge = ClaudeJudge(api_key="test-key")
+        system_prompt, user_prompt = judge._build_relevance_prompt(
+            query="What is X?",
+            response="X is Y.",
+        )
+
+        assert "What is X?" in user_prompt
+        assert "X is Y." in user_prompt
+        assert "relevance" in system_prompt.lower()
+
+
+class TestClaudeJudgeApiCallParameters:
+    """Tests for API call parameter handling."""
+
+    @pytest.mark.asyncio
+    async def test_uses_config_parameters(
+        self,
+        mock_anthropic_client: MagicMock,
+        mock_response: MagicMock,
+    ) -> None:
+        """Test that API calls use configuration parameters."""
+        mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
+
+        config = JudgeConfig(model="claude-opus-4-20250514", temperature=0.5, max_tokens=2048)
+        judge = ClaudeJudge(config=config, api_key="test-key")
+
+        await judge.evaluate_faithfulness(
+            response="Test",
+            context=["Context"],
+        )
+
+        call_kwargs = mock_anthropic_client.messages.create.call_args.kwargs
+        assert call_kwargs["model"] == "claude-opus-4-20250514"
+        assert call_kwargs["temperature"] == 0.5
+        assert call_kwargs["max_tokens"] == 2048


### PR DESCRIPTION
## Summary
- Implements `ClaudeJudge` class extending `LLMJudge` base for evaluating RAG responses
- Adds async API calls with tenacity retry logic (3 attempts, exponential backoff)
- Includes structured JSON output parsing with markdown code block handling
- Comprehensive error handling with `JudgeAPIError` and `JudgeResponseError`

## Changes
- `src/ragaliq/judges/claude.py` - New ClaudeJudge implementation
- `src/ragaliq/judges/__init__.py` - Export ClaudeJudge
- `tests/unit/test_claude_judge.py` - 23 unit tests

## Test plan
- [x] All 67 unit tests pass
- [x] Linting passes (`hatch run lint`)
- [x] Type checking passes (`hatch run typecheck`)
- [x] 76% code coverage on claude.py

🤖 Generated with [Claude Code](https://claude.com/claude-code)