### PR TITLE
[FEAT #6] Task 5: FaithfulnessEvaluator

### DIFF
--- a/docs/decisions/task_6_analysis.md
+++ b/docs/decisions/task_6_analysis.md
@@ -1,0 +1,274 @@
+# Task 6: FaithfulnessEvaluator - Design Decision Record
+
+**Issue**: [#6 - Task 5: FaithfulnessEvaluator](https://github.com/dariero/RagaliQ/issues/6)
+**Date**: 2026-02-05
+**Status**: Implemented
+
+---
+
+## 1. Problem Statement
+
+Implement an evaluator that measures whether an LLM response is **faithful** to the provided context - meaning every claim is grounded in the context with no hallucinations or fabricated information.
+
+### Acceptance Criteria (from Issue #6)
+
+| Scenario | Expected Score |
+|----------|---------------|
+| All claims supported | 1.0 |
+| Half supported | 0.5 |
+| No claims (empty) | 1.0 (vacuously faithful) |
+| All unsupported | 0.0 |
+
+---
+
+## 2. Chosen Approach: Claim-Level Decomposition
+
+### Architecture
+
+```
+FaithfulnessEvaluator
+    │
+    ├─── 1. judge.extract_claims(response) → ClaimsResult
+    │         └─── Returns: ["claim 1", "claim 2", ...]
+    │
+    ├─── 2. For each claim:
+    │         judge.verify_claim(claim, context) → ClaimVerdict
+    │         └─── Returns: {verdict: SUPPORTED|CONTRADICTED|NOT_ENOUGH_INFO, evidence: "..."}
+    │
+    └─── 3. Calculate: score = supported_count / total_claims
+              └─── Returns: EvaluationResult with metadata
+```
+
+### Why This Approach
+
+| Criterion | Claim-Level | Holistic Alternative |
+|-----------|-------------|----------------------|
+| **Debuggability** | See exactly which claims failed | Black-box score only |
+| **Actionability** | Users can fix specific sentences | Must rewrite entire response |
+| **Granularity** | Fine-grained 0.0-1.0 scoring | Often binary-feeling |
+| **Metadata** | Detailed claim breakdown in `raw_response` | None |
+| **Testability** | Each step independently testable | Single integration test |
+
+---
+
+## 3. Alternatives Considered
+
+### Alternative A: Holistic Evaluation (Rejected)
+
+**Approach**: Use existing `judge.evaluate_faithfulness()` method that returns a single score.
+
+```python
+# Would have been simple:
+result = await judge.evaluate_faithfulness(response, context)
+return EvaluationResult(score=result.score, ...)
+```
+
+**Why Rejected**:
+- No claim-level metadata (`metadata["claims"]` was required per issue spec)
+- Users can't understand why they got 0.6 vs 0.8
+- Violates issue specification requiring claim extraction algorithm
+- Less testable - can only verify final score
+
+### Alternative B: Evaluator Calls Claude Directly (Rejected)
+
+**Approach**: Have the evaluator make direct API calls using prompt templates, bypassing the judge abstraction.
+
+```python
+class FaithfulnessEvaluator(Evaluator):
+    def __init__(self, api_key: str):
+        self.client = AsyncAnthropic(api_key=api_key)
+
+    async def evaluate(self, test_case, judge):  # judge ignored
+        # Direct API calls here
+```
+
+**Why Rejected**:
+- Violates **Dependency Inversion Principle** - evaluator depends on concrete Claude, not abstraction
+- Untestable without mocking Anthropic client
+- Breaks architecture - judge exists to encapsulate LLM calls
+- Duplicate API key management
+- Can't swap LLM providers (tightly coupled to Claude)
+
+---
+
+## 4. Design Patterns Applied
+
+### 4.1 Strategy Pattern
+
+The `LLMJudge` interface acts as the strategy. Evaluators work with any judge implementation.
+
+```python
+class LLMJudge(ABC):
+    @abstractmethod
+    async def extract_claims(self, response: str) -> ClaimsResult: ...
+
+    @abstractmethod
+    async def verify_claim(self, claim: str, context: list[str]) -> ClaimVerdict: ...
+```
+
+### 4.2 Dependency Injection
+
+Judge is injected into `evaluate()` method, not constructed internally:
+
+```python
+async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+    # Judge is provided, not created
+    claims = await judge.extract_claims(test_case.response)
+```
+
+### 4.3 Value Objects (Pydantic)
+
+All data models are immutable Pydantic models:
+
+```python
+class ClaimVerdict(BaseModel):
+    verdict: Literal["SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO"]
+    evidence: str = ""
+    model_config = {"frozen": True}
+```
+
+### 4.4 Template Method
+
+Base `Evaluator` provides `is_passing()` helper; subclasses implement `evaluate()`:
+
+```python
+class Evaluator(ABC):
+    def is_passing(self, score: float) -> bool:
+        return score >= self.threshold  # Provided by base
+
+    @abstractmethod
+    async def evaluate(self, ...) -> EvaluationResult:
+        pass  # Implemented by subclass
+```
+
+---
+
+## 5. SOLID Principles
+
+| Principle | Application |
+|-----------|-------------|
+| **S**ingle Responsibility | Evaluator only orchestrates; Judge handles LLM calls |
+| **O**pen/Closed | New verdict types don't require Evaluator changes |
+| **L**iskov Substitution | Any `LLMJudge` subclass works with FaithfulnessEvaluator |
+| **I**nterface Segregation | Judge methods are focused, not bloated |
+| **D**ependency Inversion | Evaluator depends on `LLMJudge` abstraction, not `ClaudeJudge` |
+
+---
+
+## 6. Test-Driven Development
+
+### Test Pyramid
+
+```
+        /\
+       /  \  Integration (existing runner tests)
+      /────\
+     /      \
+    /────────\  Unit Tests (21 new tests)
+   /          \ - Evaluator with mock judge
+  /────────────\ - Each edge case covered
+ /              \
+```
+
+### Test Categories (21 tests)
+
+1. **Attributes** (5 tests): name, description, threshold, custom threshold, repr
+2. **Acceptance Criteria** (4 tests): all supported, half supported, no claims, all unsupported
+3. **Verdict Handling** (3 tests): contradicted, not_enough_info, mixed verdicts
+4. **Metadata** (2 tests): claim details, summary stats
+5. **Result Structure** (3 tests): EvaluationResult type, evaluator name, reasoning
+6. **Edge Cases** (4 tests): single claim, precision with many claims, threshold logic
+
+### Mock Strategy
+
+```python
+@pytest.fixture
+def mock_judge():
+    judge = MagicMock(spec=LLMJudge)
+    judge.extract_claims = AsyncMock(return_value=ClaimsResult(claims=[...]))
+    judge.verify_claim = AsyncMock(side_effect=[...])
+    return judge
+```
+
+---
+
+## 7. Files Changed
+
+| File | Change | Description |
+|------|--------|-------------|
+| `src/ragaliq/judges/base.py` | Modified | Added `ClaimsResult`, `ClaimVerdict` models and abstract methods |
+| `src/ragaliq/judges/claude.py` | Modified | Implemented `extract_claims()`, `verify_claim()` using YAML templates |
+| `src/ragaliq/judges/__init__.py` | Modified | Exported new models |
+| `src/ragaliq/evaluators/faithfulness.py` | **Created** | Main evaluator implementation |
+| `src/ragaliq/evaluators/__init__.py` | Modified | Exported `FaithfulnessEvaluator` |
+| `tests/unit/test_faithfulness_evaluator.py` | **Created** | 21 unit tests |
+| `tests/unit/test_claude_judge.py` | Modified | Added tests for new judge methods |
+| `tests/unit/test_judges.py` | Modified | Updated mock implementations |
+
+---
+
+## 8. API Surface
+
+### New Models
+
+```python
+from ragaliq.judges import ClaimsResult, ClaimVerdict
+
+# Extract claims
+claims_result = await judge.extract_claims("Paris is the capital of France.")
+# ClaimsResult(claims=["Paris is the capital of France"], tokens_used=50)
+
+# Verify claim
+verdict = await judge.verify_claim(
+    claim="Paris is the capital of France",
+    context=["France is a country. Its capital is Paris."]
+)
+# ClaimVerdict(verdict="SUPPORTED", evidence="Context states this")
+```
+
+### FaithfulnessEvaluator Usage
+
+```python
+from ragaliq.evaluators import FaithfulnessEvaluator
+
+evaluator = FaithfulnessEvaluator(threshold=0.8)
+result = await evaluator.evaluate(test_case, judge)
+
+print(f"Score: {result.score}")  # 0.75
+print(f"Passed: {result.passed}")  # False (0.75 < 0.8)
+
+# Inspect individual claims
+for claim in result.raw_response["claims"]:
+    print(f"{claim['verdict']}: {claim['claim']}")
+```
+
+---
+
+## 9. Edge Cases Handled
+
+| Edge Case | Behavior |
+|-----------|----------|
+| Empty response | Returns score 1.0 (vacuously faithful) |
+| Empty context | `verify_claim` returns `NOT_ENOUGH_INFO` |
+| Whitespace-only response | Returns score 1.0 (no claims) |
+| Invalid verdict from LLM | `JudgeResponseError` raised |
+| Lowercase verdict from LLM | Normalized to uppercase |
+
+---
+
+## 10. Future Considerations
+
+1. **Performance**: For responses with many claims (100+), consider parallel verification or batching
+2. **Caching**: Extract claims could be cached if same response evaluated multiple times
+3. **Partial Support**: Future enhancement could track `PARTIALLY_SUPPORTED` verdict
+4. **Scoring Variants**: Could offer weighted scoring (contradicted = -1, not_enough_info = 0, supported = 1)
+
+---
+
+## 11. Quality Gates
+
+```bash
+make test       # 149 passed, 1 skipped
+make lint       # All checks passed
+make typecheck  # All checks passed
+```

--- a/src/ragaliq/evaluators/__init__.py
+++ b/src/ragaliq/evaluators/__init__.py
@@ -1,1 +1,7 @@
-# Evaluators package
+"""Evaluators package for RagaliQ."""
+
+from ragaliq.evaluators.faithfulness import FaithfulnessEvaluator
+
+__all__ = [
+    "FaithfulnessEvaluator",
+]

--- a/src/ragaliq/evaluators/faithfulness.py
+++ b/src/ragaliq/evaluators/faithfulness.py
@@ -1,0 +1,162 @@
+"""
+Faithfulness evaluator for RagaliQ.
+
+This module implements claim-level faithfulness evaluation, measuring whether
+an LLM response is grounded only in the provided context without hallucinations.
+
+Algorithm:
+    1. Extract atomic claims from the response
+    2. Verify each claim against the context (SUPPORTED/CONTRADICTED/NOT_ENOUGH_INFO)
+    3. Score = supported_claims / total_claims
+    4. Empty claims = 1.0 (vacuously faithful)
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ragaliq.core.evaluator import EvaluationResult, Evaluator
+
+if TYPE_CHECKING:
+    from ragaliq.core.test_case import RAGTestCase
+    from ragaliq.judges.base import LLMJudge
+
+
+class FaithfulnessEvaluator(Evaluator):
+    """
+    Evaluator that measures response faithfulness to context.
+
+    Faithfulness means every claim in the response is supported by the context.
+    A faithful response does not hallucinate or add information beyond what
+    the context provides.
+
+    This evaluator uses claim-level decomposition:
+    1. Extract atomic claims from the response
+    2. Verify each claim against the context
+    3. Calculate score as ratio of supported claims
+
+    Attributes:
+        name: "faithfulness" - unique identifier for this evaluator.
+        description: Human-readable description of what is evaluated.
+        threshold: Minimum score to pass (default 0.7).
+
+    Example:
+        evaluator = FaithfulnessEvaluator(threshold=0.8)
+        result = await evaluator.evaluate(test_case, judge)
+
+        if result.passed:
+            print(f"Response is faithful: {result.score:.2f}")
+        else:
+            # Inspect which claims failed
+            for claim in result.raw_response["claims"]:
+                if claim["verdict"] != "SUPPORTED":
+                    print(f"Unsupported: {claim['claim']}")
+    """
+
+    name: str = "faithfulness"
+    description: str = "Measures if response is grounded only in context"
+
+    async def evaluate(
+        self,
+        test_case: RAGTestCase,
+        judge: LLMJudge,
+    ) -> EvaluationResult:
+        """
+        Evaluate faithfulness of the response to the context.
+
+        Implements the claim-based faithfulness algorithm:
+        1. Extract claims from response via judge.extract_claims()
+        2. Verify each claim via judge.verify_claim()
+        3. Score = supported_claims / total_claims
+        4. Empty claims = 1.0 (vacuously faithful)
+
+        Args:
+            test_case: The RAG test case containing response and context.
+            judge: The LLM judge instance for claim extraction and verification.
+
+        Returns:
+            EvaluationResult with:
+                - score: Ratio of supported claims (0.0 to 1.0)
+                - passed: Whether score meets threshold
+                - reasoning: Human-readable explanation
+                - raw_response: Detailed claim-level metadata
+        """
+        # Step 1: Extract atomic claims from the response
+        claims_result = await judge.extract_claims(test_case.response)
+        claims = claims_result.claims
+
+        # Handle empty claims edge case: vacuously faithful
+        if not claims:
+            return EvaluationResult(
+                evaluator_name=self.name,
+                score=1.0,
+                passed=True,
+                reasoning="No claims to verify; response is vacuously faithful.",
+                raw_response={
+                    "claims": [],
+                    "total_claims": 0,
+                    "supported_claims": 0,
+                },
+            )
+
+        # Step 2: Verify each claim against the context
+        claim_details: list[dict[str, Any]] = []
+        supported_count = 0
+
+        for claim in claims:
+            verdict = await judge.verify_claim(claim, test_case.context)
+
+            claim_details.append({
+                "claim": claim,
+                "verdict": verdict.verdict,
+                "evidence": verdict.evidence,
+            })
+
+            if verdict.verdict == "SUPPORTED":
+                supported_count += 1
+
+        # Step 3: Calculate score as ratio
+        total_claims = len(claims)
+        score = supported_count / total_claims
+
+        # Step 4: Build reasoning
+        reasoning = self._build_reasoning(supported_count, total_claims)
+
+        return EvaluationResult(
+            evaluator_name=self.name,
+            score=score,
+            passed=self.is_passing(score),
+            reasoning=reasoning,
+            raw_response={
+                "claims": claim_details,
+                "total_claims": total_claims,
+                "supported_claims": supported_count,
+            },
+        )
+
+    def _build_reasoning(self, supported: int, total: int) -> str:
+        """
+        Build human-readable reasoning for the faithfulness score.
+
+        Args:
+            supported: Number of supported claims.
+            total: Total number of claims.
+
+        Returns:
+            Reasoning string explaining the score calculation.
+        """
+        if total == 0:
+            return "No claims to verify."
+
+        unsupported = total - supported
+        score_pct = (supported / total) * 100
+
+        if supported == total:
+            return f"All {total} claims are supported by the context."
+        elif supported == 0:
+            return f"None of the {total} claims are supported by the context."
+        else:
+            return (
+                f"{supported} of {total} claims are supported ({score_pct:.0f}%). "
+                f"{unsupported} claim(s) not grounded in context."
+            )

--- a/src/ragaliq/judges/__init__.py
+++ b/src/ragaliq/judges/__init__.py
@@ -1,6 +1,8 @@
 """LLM Judges package for RagaliQ."""
 
 from ragaliq.judges.base import (
+    ClaimsResult,
+    ClaimVerdict,
     JudgeAPIError,
     JudgeConfig,
     JudgeError,
@@ -11,6 +13,8 @@ from ragaliq.judges.base import (
 from ragaliq.judges.claude import ClaudeJudge
 
 __all__ = [
+    "ClaimsResult",
+    "ClaimVerdict",
     "ClaudeJudge",
     "JudgeAPIError",
     "JudgeConfig",

--- a/tests/unit/test_faithfulness_evaluator.py
+++ b/tests/unit/test_faithfulness_evaluator.py
@@ -1,0 +1,507 @@
+"""Unit tests for FaithfulnessEvaluator.
+
+Tests follow the acceptance criteria from Issue #6:
+- All claims supported -> 1.0
+- Half supported -> 0.5
+- No claims -> 1.0 (vacuously faithful)
+- All unsupported -> 0.0
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ragaliq.core.evaluator import EvaluationResult
+from ragaliq.core.test_case import RAGTestCase
+from ragaliq.evaluators.faithfulness import FaithfulnessEvaluator
+from ragaliq.judges.base import ClaimsResult, ClaimVerdict, LLMJudge
+
+if TYPE_CHECKING:
+    pass
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_judge() -> MagicMock:
+    """Create a mock LLM judge with claim extraction and verification."""
+    judge = MagicMock(spec=LLMJudge)
+    # Default: no claims extracted
+    judge.extract_claims = AsyncMock(return_value=ClaimsResult(claims=[]))
+    judge.verify_claim = AsyncMock()
+    return judge
+
+
+@pytest.fixture
+def faithful_test_case() -> RAGTestCase:
+    """A test case where response should be faithful to context."""
+    return RAGTestCase(
+        id="faithful_001",
+        name="Faithful Response",
+        query="What is the capital of France?",
+        context=[
+            "France is a country in Western Europe.",
+            "The capital city of France is Paris.",
+        ],
+        response="The capital of France is Paris.",
+    )
+
+
+@pytest.fixture
+def hallucinating_test_case() -> RAGTestCase:
+    """A test case where response contains hallucinations."""
+    return RAGTestCase(
+        id="hallucinate_001",
+        name="Hallucinating Response",
+        query="What is the capital of France?",
+        context=[
+            "France is a country in Western Europe.",
+            "The capital city of France is Paris.",
+        ],
+        response="Paris is the capital of France and was founded by Romans in 250 BC.",
+    )
+
+
+# =============================================================================
+# Test Class Attributes
+# =============================================================================
+
+
+class TestFaithfulnessEvaluatorAttributes:
+    """Tests for evaluator class attributes and initialization."""
+
+    def test_has_required_name(self) -> None:
+        """Evaluator must have 'faithfulness' as name."""
+        evaluator = FaithfulnessEvaluator()
+        assert evaluator.name == "faithfulness"
+
+    def test_has_description(self) -> None:
+        """Evaluator must have a meaningful description."""
+        evaluator = FaithfulnessEvaluator()
+        assert evaluator.description
+        assert len(evaluator.description) > 10
+
+    def test_default_threshold_is_0_7(self) -> None:
+        """Default threshold should be 0.7 per base class."""
+        evaluator = FaithfulnessEvaluator()
+        assert evaluator.threshold == 0.7
+
+    def test_custom_threshold(self) -> None:
+        """Should accept custom threshold in constructor."""
+        evaluator = FaithfulnessEvaluator(threshold=0.9)
+        assert evaluator.threshold == 0.9
+
+    def test_repr(self) -> None:
+        """Should have a meaningful string representation."""
+        evaluator = FaithfulnessEvaluator(threshold=0.8)
+        assert "FaithfulnessEvaluator" in repr(evaluator)
+        assert "0.8" in repr(evaluator)
+
+
+# =============================================================================
+# Acceptance Criteria Tests
+# =============================================================================
+
+
+class TestFaithfulnessEvaluatorAcceptanceCriteria:
+    """Tests directly from Issue #6 acceptance criteria."""
+
+    @pytest.mark.asyncio
+    async def test_all_claims_supported_returns_1_0(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """AC: All claims supported -> 1.0"""
+        # Arrange: 2 claims, both supported
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=[
+                "France has a capital city",
+                "The capital of France is Paris",
+            ]
+        )
+        mock_judge.verify_claim.side_effect = [
+            ClaimVerdict(verdict="SUPPORTED", evidence="Context states this"),
+            ClaimVerdict(verdict="SUPPORTED", evidence="Context confirms Paris"),
+        ]
+
+        # Act
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        # Assert
+        assert result.score == 1.0
+        assert result.passed is True
+
+    @pytest.mark.asyncio
+    async def test_half_supported_returns_0_5(
+        self,
+        mock_judge: MagicMock,
+        hallucinating_test_case: RAGTestCase,
+    ) -> None:
+        """AC: Half supported -> 0.5"""
+        # Arrange: 2 claims, 1 supported, 1 not
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=[
+                "Paris is the capital of France",
+                "Paris was founded by Romans in 250 BC",
+            ]
+        )
+        mock_judge.verify_claim.side_effect = [
+            ClaimVerdict(verdict="SUPPORTED", evidence="Context confirms"),
+            ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="No founding date in context"),
+        ]
+
+        # Act
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(hallucinating_test_case, mock_judge)
+
+        # Assert
+        assert result.score == 0.5
+        assert result.passed is False  # 0.5 < 0.7 threshold
+
+    @pytest.mark.asyncio
+    async def test_no_claims_returns_1_0(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """AC: No claims -> 1.0 (vacuously faithful)"""
+        # Arrange: empty response extracts no claims
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=[])
+
+        # Act
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        # Assert
+        assert result.score == 1.0
+        assert result.passed is True
+        # verify_claim should never be called with no claims
+        mock_judge.verify_claim.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_all_unsupported_returns_0_0(
+        self,
+        mock_judge: MagicMock,
+        hallucinating_test_case: RAGTestCase,
+    ) -> None:
+        """AC: All unsupported -> 0.0"""
+        # Arrange: 2 claims, both unsupported
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=[
+                "Paris was founded in 250 BC",
+                "Romans established Paris",
+            ]
+        )
+        mock_judge.verify_claim.side_effect = [
+            ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="No date in context"),
+            ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="No Romans in context"),
+        ]
+
+        # Act
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(hallucinating_test_case, mock_judge)
+
+        # Assert
+        assert result.score == 0.0
+        assert result.passed is False
+
+
+# =============================================================================
+# Verdict Handling Tests
+# =============================================================================
+
+
+class TestFaithfulnessEvaluatorVerdictHandling:
+    """Tests for how different verdicts affect the score."""
+
+    @pytest.mark.asyncio
+    async def test_contradicted_counts_as_unsupported(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """CONTRADICTED claims should count as unsupported (0)."""
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=["Paris is in Germany"]
+        )
+        mock_judge.verify_claim.return_value = ClaimVerdict(
+            verdict="CONTRADICTED",
+            evidence="Context says France, not Germany",
+        )
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_not_enough_info_counts_as_unsupported(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """NOT_ENOUGH_INFO claims should count as unsupported (0)."""
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=["The Eiffel Tower was built in 1889"]
+        )
+        mock_judge.verify_claim.return_value = ClaimVerdict(
+            verdict="NOT_ENOUGH_INFO",
+            evidence="No construction date in context",
+        )
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_mixed_verdicts_calculation(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """Test score with mix of SUPPORTED, CONTRADICTED, NOT_ENOUGH_INFO."""
+        # 4 claims: 2 supported, 1 contradicted, 1 not enough info
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=["Claim 1", "Claim 2", "Claim 3", "Claim 4"]
+        )
+        mock_judge.verify_claim.side_effect = [
+            ClaimVerdict(verdict="SUPPORTED", evidence="Found in context"),
+            ClaimVerdict(verdict="SUPPORTED", evidence="Also in context"),
+            ClaimVerdict(verdict="CONTRADICTED", evidence="Context says opposite"),
+            ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="Not mentioned"),
+        ]
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        # 2 supported / 4 total = 0.5
+        assert result.score == 0.5
+
+
+# =============================================================================
+# Metadata Tests
+# =============================================================================
+
+
+class TestFaithfulnessEvaluatorMetadata:
+    """Tests for claim details in raw_response metadata."""
+
+    @pytest.mark.asyncio
+    async def test_raw_response_contains_claim_details(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """raw_response should contain claim-level details for debugging."""
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=["Paris is the capital"]
+        )
+        mock_judge.verify_claim.return_value = ClaimVerdict(
+            verdict="SUPPORTED",
+            evidence="Context confirms this",
+        )
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        # Should have claims list in raw_response
+        assert "claims" in result.raw_response
+        claims = result.raw_response["claims"]
+        assert len(claims) == 1
+        assert claims[0]["claim"] == "Paris is the capital"
+        assert claims[0]["verdict"] == "SUPPORTED"
+        assert claims[0]["evidence"] == "Context confirms this"
+
+    @pytest.mark.asyncio
+    async def test_raw_response_contains_summary_stats(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """raw_response should contain summary statistics."""
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=["Claim 1", "Claim 2", "Claim 3"]
+        )
+        mock_judge.verify_claim.side_effect = [
+            ClaimVerdict(verdict="SUPPORTED", evidence=""),
+            ClaimVerdict(verdict="SUPPORTED", evidence=""),
+            ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence=""),
+        ]
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        assert result.raw_response["total_claims"] == 3
+        assert result.raw_response["supported_claims"] == 2
+
+
+# =============================================================================
+# Result Structure Tests
+# =============================================================================
+
+
+class TestFaithfulnessEvaluatorResultStructure:
+    """Tests for EvaluationResult structure compliance."""
+
+    @pytest.mark.asyncio
+    async def test_returns_evaluation_result(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """evaluate() should return EvaluationResult instance."""
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=[])
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        assert isinstance(result, EvaluationResult)
+
+    @pytest.mark.asyncio
+    async def test_evaluator_name_in_result(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """Result should contain evaluator name."""
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=[])
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        assert result.evaluator_name == "faithfulness"
+
+    @pytest.mark.asyncio
+    async def test_reasoning_explains_score(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """Result reasoning should explain how score was calculated."""
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=["Claim 1", "Claim 2"]
+        )
+        mock_judge.verify_claim.side_effect = [
+            ClaimVerdict(verdict="SUPPORTED", evidence=""),
+            ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence=""),
+        ]
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        # Reasoning should mention claim counts
+        assert "1" in result.reasoning  # 1 supported
+        assert "2" in result.reasoning  # 2 total
+
+
+# =============================================================================
+# Edge Cases
+# =============================================================================
+
+
+class TestFaithfulnessEvaluatorEdgeCases:
+    """Tests for edge cases and boundary conditions."""
+
+    @pytest.mark.asyncio
+    async def test_single_claim_supported(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """Single supported claim should give score 1.0."""
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=["Only claim"]
+        )
+        mock_judge.verify_claim.return_value = ClaimVerdict(
+            verdict="SUPPORTED", evidence=""
+        )
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        assert result.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_single_claim_unsupported(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """Single unsupported claim should give score 0.0."""
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=["Only claim"]
+        )
+        mock_judge.verify_claim.return_value = ClaimVerdict(
+            verdict="NOT_ENOUGH_INFO", evidence=""
+        )
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        assert result.score == 0.0
+
+    @pytest.mark.asyncio
+    async def test_many_claims_precision(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """Score should handle many claims with proper precision."""
+        # 7 claims, 5 supported = 5/7 ≈ 0.714...
+        claims = [f"Claim {i}" for i in range(7)]
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=claims)
+        mock_judge.verify_claim.side_effect = [
+            ClaimVerdict(verdict="SUPPORTED", evidence="") for _ in range(5)
+        ] + [
+            ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="") for _ in range(2)
+        ]
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        expected = 5 / 7
+        assert abs(result.score - expected) < 0.001
+
+    @pytest.mark.asyncio
+    async def test_passed_uses_threshold_correctly(
+        self,
+        mock_judge: MagicMock,
+        faithful_test_case: RAGTestCase,
+    ) -> None:
+        """passed field should correctly use is_passing() with threshold."""
+        # Score will be 0.7 exactly (7/10)
+        claims = [f"Claim {i}" for i in range(10)]
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=claims)
+
+        def create_verdicts() -> list[ClaimVerdict]:
+            """Create fresh verdicts list for each evaluation."""
+            return [
+                ClaimVerdict(verdict="SUPPORTED", evidence="") for _ in range(7)
+            ] + [
+                ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="") for _ in range(3)
+            ]
+
+        # Default threshold is 0.7
+        mock_judge.verify_claim.side_effect = create_verdicts()
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(faithful_test_case, mock_judge)
+
+        assert result.score == 0.7
+        assert result.passed is True  # 0.7 >= 0.7
+
+        # With higher threshold - reset side_effect for fresh iteration
+        mock_judge.verify_claim.side_effect = create_verdicts()
+        evaluator_strict = FaithfulnessEvaluator(threshold=0.8)
+        result_strict = await evaluator_strict.evaluate(faithful_test_case, mock_judge)
+
+        assert result_strict.score == 0.7
+        assert result_strict.passed is False  # 0.7 < 0.8

--- a/tests/unit/test_judges.py
+++ b/tests/unit/test_judges.py
@@ -4,6 +4,8 @@ import pytest
 from pydantic import ValidationError
 
 from ragaliq.judges import (
+    ClaimsResult,
+    ClaimVerdict,
     JudgeAPIError,
     JudgeConfig,
     JudgeError,
@@ -190,6 +192,14 @@ class TestLLMJudge:
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
 
+            async def extract_claims(self, _response: str) -> ClaimsResult:
+                return ClaimsResult(claims=[])
+
+            async def verify_claim(
+                self, _claim: str, _context: list[str]
+            ) -> ClaimVerdict:
+                return ClaimVerdict(verdict="SUPPORTED")
+
         judge = MockJudge()
         assert judge.config.model == "claude-sonnet-4-20250514"
         assert judge.config.temperature == 0.0
@@ -207,6 +217,14 @@ class TestLLMJudge:
                 self, _query: str, _response: str
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
+
+            async def extract_claims(self, _response: str) -> ClaimsResult:
+                return ClaimsResult(claims=[])
+
+            async def verify_claim(
+                self, _claim: str, _context: list[str]
+            ) -> ClaimVerdict:
+                return ClaimVerdict(verdict="SUPPORTED")
 
         config = JudgeConfig(model="gpt-4", temperature=0.3)
         judge = MockJudge(config=config)
@@ -226,6 +244,14 @@ class TestLLMJudge:
                 self, _query: str, _response: str
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
+
+            async def extract_claims(self, _response: str) -> ClaimsResult:
+                return ClaimsResult(claims=[])
+
+            async def verify_claim(
+                self, _claim: str, _context: list[str]
+            ) -> ClaimVerdict:
+                return ClaimVerdict(verdict="SUPPORTED")
 
         judge = MockJudge()
         assert repr(judge) == "MockJudge(model='claude-sonnet-4-20250514')"
@@ -248,6 +274,14 @@ class TestLLMJudge:
                 self, query: str, response: str  # noqa: ARG002
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
+
+            async def extract_claims(self, _response: str) -> ClaimsResult:
+                return ClaimsResult(claims=[])
+
+            async def verify_claim(
+                self, _claim: str, _context: list[str]
+            ) -> ClaimVerdict:
+                return ClaimVerdict(verdict="SUPPORTED")
 
         judge = MockJudge()
         result = await judge.evaluate_faithfulness(
@@ -276,6 +310,14 @@ class TestLLMJudge:
                     tokens_used=80,
                 )
 
+            async def extract_claims(self, _response: str) -> ClaimsResult:
+                return ClaimsResult(claims=[])
+
+            async def verify_claim(
+                self, _claim: str, _context: list[str]
+            ) -> ClaimVerdict:
+                return ClaimVerdict(verdict="SUPPORTED")
+
         judge = MockJudge()
         result = await judge.evaluate_relevance(
             query="What is the capital of France?",
@@ -287,7 +329,7 @@ class TestLLMJudge:
     def test_missing_abstract_method_faithfulness(self) -> None:
         """Test that missing evaluate_faithfulness raises TypeError."""
 
-        with pytest.raises(TypeError, match="evaluate_faithfulness"):
+        with pytest.raises(TypeError, match="abstract"):
 
             class IncompleteJudge(LLMJudge):  # type: ignore[abstract]
                 async def evaluate_relevance(
@@ -295,17 +337,77 @@ class TestLLMJudge:
                 ) -> JudgeResult:
                     return JudgeResult(score=1.0)
 
+                async def extract_claims(self, _response: str) -> ClaimsResult:
+                    return ClaimsResult(claims=[])
+
+                async def verify_claim(
+                    self, _claim: str, _context: list[str]
+                ) -> ClaimVerdict:
+                    return ClaimVerdict(verdict="SUPPORTED")
+
             IncompleteJudge()
 
     def test_missing_abstract_method_relevance(self) -> None:
         """Test that missing evaluate_relevance raises TypeError."""
 
-        with pytest.raises(TypeError, match="evaluate_relevance"):
+        with pytest.raises(TypeError, match="abstract"):
 
             class IncompleteJudge(LLMJudge):  # type: ignore[abstract]
                 async def evaluate_faithfulness(
                     self, _response: str, _context: list[str]
                 ) -> JudgeResult:
                     return JudgeResult(score=1.0)
+
+                async def extract_claims(self, _response: str) -> ClaimsResult:
+                    return ClaimsResult(claims=[])
+
+                async def verify_claim(
+                    self, _claim: str, _context: list[str]
+                ) -> ClaimVerdict:
+                    return ClaimVerdict(verdict="SUPPORTED")
+
+            IncompleteJudge()
+
+    def test_missing_abstract_method_extract_claims(self) -> None:
+        """Test that missing extract_claims raises TypeError."""
+
+        with pytest.raises(TypeError, match="abstract"):
+
+            class IncompleteJudge(LLMJudge):  # type: ignore[abstract]
+                async def evaluate_faithfulness(
+                    self, _response: str, _context: list[str]
+                ) -> JudgeResult:
+                    return JudgeResult(score=1.0)
+
+                async def evaluate_relevance(
+                    self, _query: str, _response: str
+                ) -> JudgeResult:
+                    return JudgeResult(score=1.0)
+
+                async def verify_claim(
+                    self, _claim: str, _context: list[str]
+                ) -> ClaimVerdict:
+                    return ClaimVerdict(verdict="SUPPORTED")
+
+            IncompleteJudge()
+
+    def test_missing_abstract_method_verify_claim(self) -> None:
+        """Test that missing verify_claim raises TypeError."""
+
+        with pytest.raises(TypeError, match="abstract"):
+
+            class IncompleteJudge(LLMJudge):  # type: ignore[abstract]
+                async def evaluate_faithfulness(
+                    self, _response: str, _context: list[str]
+                ) -> JudgeResult:
+                    return JudgeResult(score=1.0)
+
+                async def evaluate_relevance(
+                    self, _query: str, _response: str
+                ) -> JudgeResult:
+                    return JudgeResult(score=1.0)
+
+                async def extract_claims(self, _response: str) -> ClaimsResult:
+                    return ClaimsResult(claims=[])
 
             IncompleteJudge()


### PR DESCRIPTION
Closes #6

## Changes
- Add `ClaimsResult` and `ClaimVerdict` models to judge base
- Extend `LLMJudge` with `extract_claims()` and `verify_claim()` abstract methods
- Implement ClaudeJudge methods using existing YAML prompt templates
- Create `FaithfulnessEvaluator` with claim-based algorithm:
  - Extract atomic claims from response
  - Verify each claim against context (SUPPORTED/CONTRADICTED/NOT_ENOUGH_INFO)
  - Score = supported_claims / total_claims
  - Empty claims = 1.0 (vacuously faithful)
- Add 21 unit tests for evaluator + 12 tests for new judge methods
- Add design decision record in `docs/decisions/task_6_analysis.md`

## Checks
- [x] Lint passed
- [x] Type check passed
- [x] Tests passed (149 passed)

🤖 Shipped with Claude Code