### PR TITLE
[DOCS] Harden .claude/ prompt configuration from audit findings

### DIFF
--- a/.claude/CONSTANTS.md
+++ b/.claude/CONSTANTS.md
@@ -1,0 +1,39 @@
+# Project Constants
+
+Shared configuration referenced by `/start-work` and `/ship`.
+
+```
+OWNER:         dariero
+PROJECT_ID:    PVT_kwHODR8J4s4BNe_Y
+PROJECT_NUM:   2
+STATUS_FIELD:  PVTSSF_lAHODR8J4s4BNe_Yzg8dwP8
+
+Board statuses:
+  Todo:   98236657
+  Doing:  47fc9ee4
+  Done:   caff0873
+```
+
+**Board URL:** https://github.com/users/dariero/projects/2/views/1
+
+## Branch Naming
+
+Format: `<prefix>/<issue>-<description>`
+
+| Title Prefix | Branch Prefix |
+|--------------|---------------|
+| `[FEAT]` | `feat/` |
+| `[FIX]` | `fix/` |
+| `[REFACTOR]` | `refactor/` |
+| `[DOCS]` | `docs/` |
+| (none) | `feat/` |
+
+## Commit Format
+
+`[TYPE #issue] Description`
+
+## Quality Gates
+
+```bash
+hatch run lint && hatch run typecheck && hatch run test
+```

--- a/.claude/WORKFLOW.md
+++ b/.claude/WORKFLOW.md
@@ -18,35 +18,7 @@ RagaliQ follows three principles:
 
 These are the only two commands. Everything else is inline guidance below.
 
-## Project Constants
-
-```
-OWNER:         dariero
-PROJECT_ID:    PVT_kwHODR8J4s4BNe_Y
-PROJECT_NUM:   2
-STATUS_FIELD:  PVTSSF_lAHODR8J4s4BNe_Yzg8dwP8
-
-Board statuses:
-  Todo:   98236657
-  Doing:  47fc9ee4
-  Done:   caff0873
-```
-
-**Board URL:** https://github.com/users/dariero/projects/2/views/1
-
-**Branch naming:** `<prefix>/<issue>-<description>`
-
-| Title Prefix | Branch Prefix |
-|--------------|---------------|
-| `[FEAT]` | `feat/` |
-| `[FIX]` | `fix/` |
-| `[REFACTOR]` | `refactor/` |
-| `[DOCS]` | `docs/` |
-| (none) | `feat/` |
-
-**Commit format:** `[TYPE #issue] Description`
-
-**Quality gates:** `hatch run lint && hatch run typecheck && hatch run test`
+Project constants (IDs, branch naming, commit format) are in `.claude/CONSTANTS.md`.
 
 ---
 

--- a/.claude/commands/start-work.md
+++ b/.claude/commands/start-work.md
@@ -14,6 +14,8 @@ Begin work on a GitHub issue. Creates branch, updates board, assigns you.
 gh issue view $ARGUMENTS --json title,body,number,state
 ```
 
+Validate issue state: if `state` is `closed`, warn the user and ask whether to reopen or abort. DO NOT proceed on a closed issue without explicit confirmation.
+
 Parse type from title prefix: `[FEAT]`, `[FIX]`, `[REFACTOR]`, `[DOCS]`
 
 ### 2. Sync and Branch
@@ -23,14 +25,15 @@ git checkout main && git pull origin main
 git checkout -b <prefix>/$ARGUMENTS-<short-description>
 ```
 
-Branch prefix is derived from title prefix (see WORKFLOW.md § Project Constants).
+Branch prefix is derived from title prefix (see `.claude/CONSTANTS.md`).
 
-If uncommitted changes exist, stop and ask: stash or discard?
+If uncommitted changes exist: STOP and ask the user whether to stash or discard. DO NOT make this decision autonomously.
+
 If branch already exists, switch to it.
 
 ### 3. Update Board to Doing
 
-Use GraphQL to move the project item to "Doing" status (see WORKFLOW.md § Project Constants for IDs).
+Use GraphQL to move the project item to "Doing" status (see `.claude/CONSTANTS.md` for IDs).
 
 ### 4. Assign Self
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,29 @@
-# RagaliQ - Project Context
+# RagaliQ - Project Instructions
 
-## What is RagaliQ?
+<constraints>
+- ALWAYS run `hatch run lint && hatch run typecheck && hatch run test` before committing
+- NEVER commit files matching: .env*, *.pem, *credentials*, *secret*, .DS_Store
+- NEVER push directly to main; all work ships through `/ship`
+- NEVER add or remove dependencies without explicit user approval
+- NEVER change existing architectural patterns without explicit approval
+- Type hints MUST be present on all public functions
+- Docstrings MUST use Google style
+- Use `ruff` for linting and formatting -- no manual style overrides
+</constraints>
 
-RagaliQ (RAG + Quality) is a Python library + CLI tool for automated testing of RAG (Retrieval-Augmented Generation) pipelines. It enables QA and AI engineers to write quality tests for LLM responses using pytest-like syntax.
+## Design Decisions (MUST follow in all new code)
+
+1. **Evaluator Pattern**: Each metric MUST be a separate Evaluator class with `evaluate()` method. DO NOT refactor to alternative patterns without explicit approval.
+2. **LLM-as-Judge**: Claude API assesses response quality, not hardcoded rules.
+3. **Async-first**: All LLM calls MUST be async.
+4. **Pydantic everywhere**: Strict typing with Pydantic models for all data structures.
+5. **Pytest-native**: Library MUST feel natural to pytest users.
+
+## Project Context
+
+RagaliQ (RAG + Quality) is a Python library + CLI for automated testing of RAG pipelines. Enables QA and AI engineers to write quality tests for LLM responses using pytest-like syntax.
+
+**GitHub Board**: https://github.com/users/dariero/projects/2/views/1 — Phase 1: judge integration and core evaluators.
 
 ## Tech Stack
 
@@ -26,26 +47,12 @@ src/ragaliq/
 └── cli/            # Typer CLI commands
 ```
 
-## Key Design Decisions
-
-1. **Evaluator Pattern**: Each metric is a separate Evaluator class with `evaluate()` method
-2. **LLM-as-Judge**: Claude API assesses response quality, not hardcoded rules
-3. **Async-first**: All LLM calls are async for performance
-4. **Pydantic everywhere**: Strict typing with Pydantic models
-5. **Pytest-native**: Library feels natural to pytest users
-
 ## Code Style
 
 - Use `ruff` for linting and formatting
 - Type hints required for all public functions
 - Docstrings in Google style
 - Tests in `tests/` mirroring `src/` structure
-
-## Current Status
-
-**GitHub Board**: https://github.com/users/dariero/projects/2/views/1
-
-Phase 1 in progress - building judge integration and core evaluators.
 
 ## Commands
 
@@ -63,3 +70,4 @@ Two slash commands for the dev workflow:
 - `/ship` - Ship to main (commit + check + PR + merge + cleanup)
 
 Implementation patterns (evaluator, judge, prompt optimization) are documented in `.claude/WORKFLOW.md`.
+Project constants (IDs, branch naming, commit format) are in `.claude/CONSTANTS.md`.


### PR DESCRIPTION
## Summary

- Add `<constraints>` XML block to CLAUDE.md with explicit NEVER/MUST/ALWAYS rules (prevents scope creep, secret commits, architecture drift)
- Add `<critical>` XML block to ship.md with MANDATORY Pre-Merge Checklist elevated to top of document (fixes lost-in-the-middle attention drop)
- Replace unsafe `git add -A` with explicit file staging + exclusion list in ship.md
- Fix fragile branch regex (`grep -oE '[0-9]+'` → `sed + grep -oE '^[0-9]+'`) and add ISSUE_NUMBER validation
- Add closed-issue guard to start-work.md (DO NOT proceed without confirmation)
- Strengthen soft language ("stop and ask" → "STOP... DO NOT make this decision autonomously")
- Extract Project Constants from WORKFLOW.md into dedicated CONSTANTS.md (reduces context noise)
- Remove stale `Bash(gh pr diff 29)` permission entry from settings.local.json (gitignored, local only)

## Test plan

- [ ] Verify `/start-work <issue>` resolves `.claude/CONSTANTS.md` references correctly
- [ ] Verify `/ship` applies new explicit staging workflow instead of `git add -A`
- [ ] Verify CLAUDE.md `<constraints>` block is loaded into Claude Code system prompt
- [ ] Smoke-test branch regex with edge cases: `feat/7-add-v2-api`, `feat/v2-7-fix`

🤖 Generated with [Claude Code](https://claude.com/claude-code)