### PR TITLE
[FEAT #7] Implement RelevanceEvaluator with score passthrough

### DIFF
--- a/docs/decisions/task_7_analysis.md
+++ b/docs/decisions/task_7_analysis.md
@@ -1,0 +1,190 @@
+# Task 7: RelevanceEvaluator - Design Decision Record
+
+**Issue**: [#7 - Task 6: RelevanceEvaluator](https://github.com/dariero/RagaliQ/issues/7)
+**Date**: 2026-02-06
+**Status**: Implementing
+
+---
+
+## 1. Context
+
+Implement an evaluator that measures whether an LLM response **answers the user's query**. This is the second evaluator in RagaliQ's pipeline, following FaithfulnessEvaluator (Task 6).
+
+### Acceptance Criteria (from Issue #7)
+
+| Criterion | Requirement |
+|-----------|-------------|
+| Score passthrough | Score from judge passes directly to result (already 0-1) |
+| Reasoning included | Judge's reasoning string appears in `EvaluationResult.reasoning` |
+| Quality gates pass | `hatch run lint && hatch run typecheck && hatch run test` |
+
+### Key Constraint
+
+The issue explicitly states: *"Simplest evaluator - wraps judge method."* Unlike FaithfulnessEvaluator (which orchestrates claim extraction + verification), RelevanceEvaluator delegates the entire assessment to `judge.evaluate_relevance()`.
+
+---
+
+## 2. Proposed Solution: Thin Adapter over Judge
+
+### Architecture
+
+```
+RelevanceEvaluator.evaluate(test_case, judge)
+    │
+    └─── judge.evaluate_relevance(query, response) → JudgeResult
+              │
+              └─── Return EvaluationResult(
+                       score = judge_result.score,
+                       reasoning = judge_result.reasoning,
+                       raw_response = {score, reasoning, tokens_used}
+                   )
+```
+
+### Data Flow
+
+```
+RAGTestCase ──► RelevanceEvaluator ──► LLMJudge.evaluate_relevance() ──► JudgeResult
+                        │                                                      │
+                        │              ◄────── score, reasoning ───────────────┘
+                        │
+                        └──► EvaluationResult(
+                                evaluator_name="relevance",
+                                score=judge_score,
+                                passed=is_passing(score),
+                                reasoning=judge_reasoning,
+                                raw_response={score, reasoning, tokens_used}
+                             )
+```
+
+### Why This Approach
+
+The evaluator is intentionally thin because:
+
+1. **The judge already handles the complexity** — `evaluate_relevance()` in ClaudeJudge sends a specialized prompt, parses the JSON response, clamps the score, and handles retries. Duplicating any of this in the evaluator would violate DRY.
+
+2. **Interface conformance is the value** — The runner expects `Evaluator.evaluate()` → `EvaluationResult`. The judge returns `JudgeResult`. This evaluator bridges those two interfaces, adding threshold-based pass/fail semantics.
+
+3. **Preserves raw judge output** — Storing `tokens_used` and full `JudgeResult` data in `raw_response` enables debugging and cost tracking without leaking judge internals through the evaluator API.
+
+---
+
+## 3. Principles Applied
+
+### 3.1 Adapter Pattern
+
+RelevanceEvaluator adapts between two incompatible interfaces:
+
+| `LLMJudge.evaluate_relevance()` returns | `Evaluator.evaluate()` must return |
+|--|--|
+| `JudgeResult(score, reasoning, tokens_used)` | `EvaluationResult(evaluator_name, score, passed, reasoning, raw_response)` |
+
+The evaluator adds `evaluator_name`, computes `passed` via `is_passing()`, and packs the judge's full response into `raw_response`.
+
+### 3.2 Single Responsibility Principle
+
+- **Evaluator**: Defines *what* to evaluate (query-response relevance) and *whether* it passes (threshold comparison)
+- **Judge**: Defines *how* to evaluate (LLM prompt, parsing, scoring)
+
+The evaluator does NOT contain scoring logic, prompt templates, or API calls.
+
+### 3.3 Dependency Inversion Principle
+
+The evaluator depends on `LLMJudge` abstraction, not `ClaudeJudge` concrete class. This means:
+- Tests use `MagicMock(spec=LLMJudge)` — no API calls needed
+- Future OpenAI/local judge implementations work without evaluator changes
+
+### 3.4 Open/Closed Principle
+
+The Evaluator base class is open for extension (new evaluators) but closed for modification. RelevanceEvaluator extends it without changing the abstract interface.
+
+### 3.5 Liskov Substitution Principle
+
+RelevanceEvaluator is substitutable anywhere an `Evaluator` is expected — same `evaluate()` signature, same return type.
+
+---
+
+## 4. Alternatives Considered
+
+### Alternative A: Multi-Step Relevance with Aspect Decomposition (Rejected)
+
+**Approach**: Decompose the query into sub-questions, evaluate each against the response, aggregate scores.
+
+```python
+# Would look like:
+aspects = await judge.extract_query_aspects(query)
+for aspect in aspects:
+    score = await judge.score_aspect_coverage(aspect, response)
+```
+
+**Why Rejected**:
+- The issue spec explicitly says "wraps judge method" — this adds unnecessary complexity
+- Would require new `LLMJudge` abstract methods not yet defined
+- Over-engineering for the current phase; can be added as a separate evaluator later (e.g., `DetailedRelevanceEvaluator`)
+- More LLM calls = higher cost and latency for marginal benefit at this stage
+
+### Alternative B: Reuse `evaluate_faithfulness()` with Query as Context (Rejected)
+
+**Approach**: Treat the query as a single-item context list and reuse the faithfulness pipeline.
+
+```python
+result = await judge.evaluate_faithfulness(response, context=[query])
+```
+
+**Why Rejected**:
+- Semantic mismatch: faithfulness measures grounding in *documents*, not *query answering*
+- Would produce misleading scores — a response can be faithful to context but irrelevant to the query
+- Conflates two orthogonal quality dimensions
+- The judge already has a dedicated `evaluate_relevance()` method with a specialized prompt
+
+---
+
+## 5. Test Strategy
+
+### Mock-Based Unit Testing
+
+Following the pattern established by FaithfulnessEvaluator tests:
+
+```python
+@pytest.fixture
+def mock_judge():
+    judge = MagicMock(spec=LLMJudge)
+    judge.evaluate_relevance = AsyncMock(
+        return_value=JudgeResult(score=0.9, reasoning="...", tokens_used=100)
+    )
+    return judge
+```
+
+### Test Categories
+
+| Category | Tests | Purpose |
+|----------|-------|---------|
+| Attributes | 5 | name, description, threshold, custom threshold, repr |
+| Score Passthrough | 3 | High/medium/low scores pass through correctly |
+| Reasoning | 2 | Judge reasoning appears in result |
+| Threshold Logic | 2 | Pass/fail based on configurable threshold |
+| Raw Response | 2 | Judge metadata preserved in raw_response |
+| Result Structure | 2 | Returns correct type, evaluator_name set |
+
+### What We're NOT Testing
+
+- Judge's actual scoring logic (that's `test_claude_judge.py`)
+- Prompt quality (integration/E2E concern)
+- API retries and error handling (judge's responsibility)
+
+---
+
+## 6. Files to Create/Modify
+
+| File | Change | Description |
+|------|--------|-------------|
+| `src/ragaliq/evaluators/relevance.py` | **Create** | RelevanceEvaluator implementation |
+| `src/ragaliq/evaluators/__init__.py` | Modify | Export `RelevanceEvaluator` |
+| `tests/unit/test_relevance_evaluator.py` | **Create** | Unit tests |
+
+---
+
+## 7. Future Considerations
+
+1. **Weighted relevance**: Future evaluators could assess partial relevance (e.g., response addresses 3 of 5 query aspects)
+2. **Context-aware relevance**: A variant could factor in whether the *context* was relevant, not just the response
+3. **Comparative evaluation**: Rank multiple responses by relevance to the same query

--- a/src/ragaliq/evaluators/__init__.py
+++ b/src/ragaliq/evaluators/__init__.py
@@ -1,7 +1,9 @@
 """Evaluators package for RagaliQ."""
 
 from ragaliq.evaluators.faithfulness import FaithfulnessEvaluator
+from ragaliq.evaluators.relevance import RelevanceEvaluator
 
 __all__ = [
     "FaithfulnessEvaluator",
+    "RelevanceEvaluator",
 ]

--- a/src/ragaliq/evaluators/faithfulness.py
+++ b/src/ragaliq/evaluators/faithfulness.py
@@ -106,11 +106,13 @@ class FaithfulnessEvaluator(Evaluator):
         for claim in claims:
             verdict = await judge.verify_claim(claim, test_case.context)
 
-            claim_details.append({
-                "claim": claim,
-                "verdict": verdict.verdict,
-                "evidence": verdict.evidence,
-            })
+            claim_details.append(
+                {
+                    "claim": claim,
+                    "verdict": verdict.verdict,
+                    "evidence": verdict.evidence,
+                }
+            )
 
             if verdict.verdict == "SUPPORTED":
                 supported_count += 1

--- a/src/ragaliq/evaluators/relevance.py
+++ b/src/ragaliq/evaluators/relevance.py
@@ -1,0 +1,91 @@
+"""
+Relevance evaluator for RagaliQ.
+
+This module implements relevance evaluation, measuring whether an LLM response
+addresses the user's query. It delegates scoring entirely to the judge's
+evaluate_relevance() method and adapts the result to the Evaluator interface.
+
+Algorithm:
+    1. Call judge.evaluate_relevance(query, response)
+    2. Pass through score directly (already 0-1)
+    3. Include judge's reasoning and metadata in result
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ragaliq.core.evaluator import EvaluationResult, Evaluator
+
+if TYPE_CHECKING:
+    from ragaliq.core.test_case import RAGTestCase
+    from ragaliq.judges.base import LLMJudge
+
+
+class RelevanceEvaluator(Evaluator):
+    """
+    Evaluator that measures response relevance to the query.
+
+    Relevance means the response addresses what the user actually asked.
+    A relevant response stays on topic and provides information that
+    answers or directly relates to the query.
+
+    This evaluator delegates entirely to the judge's evaluate_relevance()
+    method, adapting the JudgeResult into an EvaluationResult with
+    threshold-based pass/fail semantics.
+
+    Attributes:
+        name: "relevance" - unique identifier for this evaluator.
+        description: Human-readable description of what is evaluated.
+        threshold: Minimum score to pass (default 0.7).
+
+    Example:
+        evaluator = RelevanceEvaluator(threshold=0.8)
+        result = await evaluator.evaluate(test_case, judge)
+
+        if result.passed:
+            print(f"Response is relevant: {result.score:.2f}")
+        else:
+            print(f"Low relevance ({result.score:.2f}): {result.reasoning}")
+    """
+
+    name: str = "relevance"
+    description: str = "Measures if response answers the query"
+
+    async def evaluate(
+        self,
+        test_case: RAGTestCase,
+        judge: LLMJudge,
+    ) -> EvaluationResult:
+        """
+        Evaluate relevance of the response to the query.
+
+        Delegates to judge.evaluate_relevance() and adapts the result.
+
+        Args:
+            test_case: The RAG test case containing query and response.
+            judge: The LLM judge instance for relevance scoring.
+
+        Returns:
+            EvaluationResult with:
+                - score: Relevance score from judge (0.0 to 1.0)
+                - passed: Whether score meets threshold
+                - reasoning: Judge's explanation of the score
+                - raw_response: Full judge metadata for debugging
+        """
+        judge_result = await judge.evaluate_relevance(
+            query=test_case.query,
+            response=test_case.response,
+        )
+
+        return EvaluationResult(
+            evaluator_name=self.name,
+            score=judge_result.score,
+            passed=self.is_passing(judge_result.score),
+            reasoning=judge_result.reasoning,
+            raw_response={
+                "score": judge_result.score,
+                "reasoning": judge_result.reasoning,
+                "tokens_used": judge_result.tokens_used,
+            },
+        )

--- a/src/ragaliq/judges/claude.py
+++ b/src/ragaliq/judges/claude.py
@@ -121,9 +121,7 @@ class ClaudeJudge(LLMJudge):
             # Extract text content from response
             content = response.content[0]
             if content.type != "text":
-                raise JudgeResponseError(
-                    f"Expected text response, got {content.type}"
-                )
+                raise JudgeResponseError(f"Expected text response, got {content.type}")
 
             # Calculate total tokens used
             tokens_used = response.usage.input_tokens + response.usage.output_tokens
@@ -297,14 +295,10 @@ Return JSON with score (0.0-1.0) and reasoning."""
                 tokens_used=0,
             )
 
-        system_prompt, user_prompt = self._build_faithfulness_prompt(
-            response, context
-        )
+        system_prompt, user_prompt = self._build_faithfulness_prompt(response, context)
 
         try:
-            raw_response, tokens_used = await self._call_claude(
-                system_prompt, user_prompt
-            )
+            raw_response, tokens_used = await self._call_claude(system_prompt, user_prompt)
         except APIConnectionError as e:
             raise JudgeAPIError(f"Connection to Claude API failed: {e}") from e
 
@@ -312,9 +306,7 @@ Return JSON with score (0.0-1.0) and reasoning."""
 
         # Validate required fields
         if "score" not in parsed:
-            raise JudgeResponseError(
-                f"Response missing 'score' field: {parsed}"
-            )
+            raise JudgeResponseError(f"Response missing 'score' field: {parsed}")
 
         score = float(parsed["score"])
         # Clamp score to valid range (defensive)
@@ -351,9 +343,7 @@ Return JSON with score (0.0-1.0) and reasoning."""
         system_prompt, user_prompt = self._build_relevance_prompt(query, response)
 
         try:
-            raw_response, tokens_used = await self._call_claude(
-                system_prompt, user_prompt
-            )
+            raw_response, tokens_used = await self._call_claude(system_prompt, user_prompt)
         except APIConnectionError as e:
             raise JudgeAPIError(f"Connection to Claude API failed: {e}") from e
 
@@ -361,9 +351,7 @@ Return JSON with score (0.0-1.0) and reasoning."""
 
         # Validate required fields
         if "score" not in parsed:
-            raise JudgeResponseError(
-                f"Response missing 'score' field: {parsed}"
-            )
+            raise JudgeResponseError(f"Response missing 'score' field: {parsed}")
 
         score = float(parsed["score"])
         # Clamp score to valid range (defensive)
@@ -400,9 +388,7 @@ Return JSON with score (0.0-1.0) and reasoning."""
         user_prompt = template.format_user_prompt(response=response)
 
         try:
-            raw_response, tokens_used = await self._call_claude(
-                template.system_prompt, user_prompt
-            )
+            raw_response, tokens_used = await self._call_claude(template.system_prompt, user_prompt)
         except APIConnectionError as e:
             raise JudgeAPIError(f"Connection to Claude API failed: {e}") from e
 
@@ -457,9 +443,7 @@ Return JSON with score (0.0-1.0) and reasoning."""
         )
 
         try:
-            raw_response, _ = await self._call_claude(
-                template.system_prompt, user_prompt
-            )
+            raw_response, _ = await self._call_claude(template.system_prompt, user_prompt)
         except APIConnectionError as e:
             raise JudgeAPIError(f"Connection to Claude API failed: {e}") from e
 

--- a/src/ragaliq/judges/prompts/loader.py
+++ b/src/ragaliq/judges/prompts/loader.py
@@ -74,12 +74,8 @@ class PromptTemplate(BaseModel):
     description: str = Field(default="", description="Template description")
     system_prompt: str = Field(..., description="System prompt for the LLM")
     user_template: str = Field(..., description="User message template with placeholders")
-    output_format: OutputFormat | None = Field(
-        default=None, description="Expected output format"
-    )
-    examples: list[PromptExample] = Field(
-        default_factory=list, description="Few-shot examples"
-    )
+    output_format: OutputFormat | None = Field(default=None, description="Expected output format")
+    examples: list[PromptExample] = Field(default_factory=list, description="Few-shot examples")
 
     model_config = {"extra": "allow"}
 
@@ -108,9 +104,7 @@ class PromptTemplate(BaseModel):
         Returns:
             Formatted context string with document separators.
         """
-        return "\n\n---\n\n".join(
-            f"Document {i + 1}:\n{doc}" for i, doc in enumerate(context)
-        )
+        return "\n\n---\n\n".join(f"Document {i + 1}:\n{doc}" for i, doc in enumerate(context))
 
     def get_examples_text(self, max_examples: int | None = None) -> str:
         """
@@ -205,6 +199,4 @@ def list_prompts() -> list[str]:
         ['extract_claims', 'faithfulness', 'relevance', 'verify_claim']
     """
     prompts_dir = _get_prompts_dir()
-    return sorted(
-        f.stem for f in prompts_dir.glob("*.yaml") if f.is_file()
-    )
+    return sorted(f.stem for f in prompts_dir.glob("*.yaml") if f.is_file())

--- a/tests/unit/test_claude_judge.py
+++ b/tests/unit/test_claude_judge.py
@@ -320,9 +320,7 @@ class TestClaudeJudgeErrorHandling:
     ) -> None:
         """Test handling of response missing score field."""
         mock_response = MagicMock()
-        mock_response.content = [
-            MagicMock(type="text", text='{"reasoning": "No score provided"}')
-        ]
+        mock_response.content = [MagicMock(type="text", text='{"reasoning": "No score provided"}')]
         mock_response.usage.input_tokens = 100
         mock_response.usage.output_tokens = 50
         mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)
@@ -545,9 +543,7 @@ class TestClaudeJudgeExtractClaims:
     ) -> None:
         """Test handling of invalid claims type in response."""
         mock_response = MagicMock()
-        mock_response.content = [
-            MagicMock(type="text", text='{"claims": "not a list"}')
-        ]
+        mock_response.content = [MagicMock(type="text", text='{"claims": "not a list"}')]
         mock_response.usage.input_tokens = 50
         mock_response.usage.output_tokens = 30
         mock_anthropic_client.messages.create = AsyncMock(return_value=mock_response)

--- a/tests/unit/test_faithfulness_evaluator.py
+++ b/tests/unit/test_faithfulness_evaluator.py
@@ -229,9 +229,7 @@ class TestFaithfulnessEvaluatorVerdictHandling:
         faithful_test_case: RAGTestCase,
     ) -> None:
         """CONTRADICTED claims should count as unsupported (0)."""
-        mock_judge.extract_claims.return_value = ClaimsResult(
-            claims=["Paris is in Germany"]
-        )
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=["Paris is in Germany"])
         mock_judge.verify_claim.return_value = ClaimVerdict(
             verdict="CONTRADICTED",
             evidence="Context says France, not Germany",
@@ -302,9 +300,7 @@ class TestFaithfulnessEvaluatorMetadata:
         faithful_test_case: RAGTestCase,
     ) -> None:
         """raw_response should contain claim-level details for debugging."""
-        mock_judge.extract_claims.return_value = ClaimsResult(
-            claims=["Paris is the capital"]
-        )
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=["Paris is the capital"])
         mock_judge.verify_claim.return_value = ClaimVerdict(
             verdict="SUPPORTED",
             evidence="Context confirms this",
@@ -387,9 +383,7 @@ class TestFaithfulnessEvaluatorResultStructure:
         faithful_test_case: RAGTestCase,
     ) -> None:
         """Result reasoning should explain how score was calculated."""
-        mock_judge.extract_claims.return_value = ClaimsResult(
-            claims=["Claim 1", "Claim 2"]
-        )
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=["Claim 1", "Claim 2"])
         mock_judge.verify_claim.side_effect = [
             ClaimVerdict(verdict="SUPPORTED", evidence=""),
             ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence=""),
@@ -418,12 +412,8 @@ class TestFaithfulnessEvaluatorEdgeCases:
         faithful_test_case: RAGTestCase,
     ) -> None:
         """Single supported claim should give score 1.0."""
-        mock_judge.extract_claims.return_value = ClaimsResult(
-            claims=["Only claim"]
-        )
-        mock_judge.verify_claim.return_value = ClaimVerdict(
-            verdict="SUPPORTED", evidence=""
-        )
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=["Only claim"])
+        mock_judge.verify_claim.return_value = ClaimVerdict(verdict="SUPPORTED", evidence="")
 
         evaluator = FaithfulnessEvaluator()
         result = await evaluator.evaluate(faithful_test_case, mock_judge)
@@ -437,12 +427,8 @@ class TestFaithfulnessEvaluatorEdgeCases:
         faithful_test_case: RAGTestCase,
     ) -> None:
         """Single unsupported claim should give score 0.0."""
-        mock_judge.extract_claims.return_value = ClaimsResult(
-            claims=["Only claim"]
-        )
-        mock_judge.verify_claim.return_value = ClaimVerdict(
-            verdict="NOT_ENOUGH_INFO", evidence=""
-        )
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=["Only claim"])
+        mock_judge.verify_claim.return_value = ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="")
 
         evaluator = FaithfulnessEvaluator()
         result = await evaluator.evaluate(faithful_test_case, mock_judge)
@@ -461,9 +447,7 @@ class TestFaithfulnessEvaluatorEdgeCases:
         mock_judge.extract_claims.return_value = ClaimsResult(claims=claims)
         mock_judge.verify_claim.side_effect = [
             ClaimVerdict(verdict="SUPPORTED", evidence="") for _ in range(5)
-        ] + [
-            ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="") for _ in range(2)
-        ]
+        ] + [ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="") for _ in range(2)]
 
         evaluator = FaithfulnessEvaluator()
         result = await evaluator.evaluate(faithful_test_case, mock_judge)
@@ -484,9 +468,7 @@ class TestFaithfulnessEvaluatorEdgeCases:
 
         def create_verdicts() -> list[ClaimVerdict]:
             """Create fresh verdicts list for each evaluation."""
-            return [
-                ClaimVerdict(verdict="SUPPORTED", evidence="") for _ in range(7)
-            ] + [
+            return [ClaimVerdict(verdict="SUPPORTED", evidence="") for _ in range(7)] + [
                 ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="") for _ in range(3)
             ]
 

--- a/tests/unit/test_judges.py
+++ b/tests/unit/test_judges.py
@@ -187,17 +187,13 @@ class TestLLMJudge:
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
 
-            async def evaluate_relevance(
-                self, _query: str, _response: str
-            ) -> JudgeResult:
+            async def evaluate_relevance(self, _query: str, _response: str) -> JudgeResult:
                 return JudgeResult(score=1.0)
 
             async def extract_claims(self, _response: str) -> ClaimsResult:
                 return ClaimsResult(claims=[])
 
-            async def verify_claim(
-                self, _claim: str, _context: list[str]
-            ) -> ClaimVerdict:
+            async def verify_claim(self, _claim: str, _context: list[str]) -> ClaimVerdict:
                 return ClaimVerdict(verdict="SUPPORTED")
 
         judge = MockJudge()
@@ -213,17 +209,13 @@ class TestLLMJudge:
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
 
-            async def evaluate_relevance(
-                self, _query: str, _response: str
-            ) -> JudgeResult:
+            async def evaluate_relevance(self, _query: str, _response: str) -> JudgeResult:
                 return JudgeResult(score=1.0)
 
             async def extract_claims(self, _response: str) -> ClaimsResult:
                 return ClaimsResult(claims=[])
 
-            async def verify_claim(
-                self, _claim: str, _context: list[str]
-            ) -> ClaimVerdict:
+            async def verify_claim(self, _claim: str, _context: list[str]) -> ClaimVerdict:
                 return ClaimVerdict(verdict="SUPPORTED")
 
         config = JudgeConfig(model="gpt-4", temperature=0.3)
@@ -240,17 +232,13 @@ class TestLLMJudge:
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
 
-            async def evaluate_relevance(
-                self, _query: str, _response: str
-            ) -> JudgeResult:
+            async def evaluate_relevance(self, _query: str, _response: str) -> JudgeResult:
                 return JudgeResult(score=1.0)
 
             async def extract_claims(self, _response: str) -> ClaimsResult:
                 return ClaimsResult(claims=[])
 
-            async def verify_claim(
-                self, _claim: str, _context: list[str]
-            ) -> ClaimVerdict:
+            async def verify_claim(self, _claim: str, _context: list[str]) -> ClaimVerdict:
                 return ClaimVerdict(verdict="SUPPORTED")
 
         judge = MockJudge()
@@ -262,7 +250,9 @@ class TestLLMJudge:
 
         class MockJudge(LLMJudge):
             async def evaluate_faithfulness(
-                self, response: str, context: list[str]  # noqa: ARG002
+                self,
+                response: str,
+                context: list[str],  # noqa: ARG002
             ) -> JudgeResult:
                 return JudgeResult(
                     score=0.9,
@@ -271,16 +261,16 @@ class TestLLMJudge:
                 )
 
             async def evaluate_relevance(
-                self, query: str, response: str  # noqa: ARG002
+                self,
+                query: str,
+                response: str,  # noqa: ARG002
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
 
             async def extract_claims(self, _response: str) -> ClaimsResult:
                 return ClaimsResult(claims=[])
 
-            async def verify_claim(
-                self, _claim: str, _context: list[str]
-            ) -> ClaimVerdict:
+            async def verify_claim(self, _claim: str, _context: list[str]) -> ClaimVerdict:
                 return ClaimVerdict(verdict="SUPPORTED")
 
         judge = MockJudge()
@@ -297,12 +287,16 @@ class TestLLMJudge:
 
         class MockJudge(LLMJudge):
             async def evaluate_faithfulness(
-                self, response: str, context: list[str]  # noqa: ARG002
+                self,
+                response: str,
+                context: list[str],  # noqa: ARG002
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
 
             async def evaluate_relevance(
-                self, query: str, response: str  # noqa: ARG002
+                self,
+                query: str,
+                response: str,  # noqa: ARG002
             ) -> JudgeResult:
                 return JudgeResult(
                     score=0.95,
@@ -313,9 +307,7 @@ class TestLLMJudge:
             async def extract_claims(self, _response: str) -> ClaimsResult:
                 return ClaimsResult(claims=[])
 
-            async def verify_claim(
-                self, _claim: str, _context: list[str]
-            ) -> ClaimVerdict:
+            async def verify_claim(self, _claim: str, _context: list[str]) -> ClaimVerdict:
                 return ClaimVerdict(verdict="SUPPORTED")
 
         judge = MockJudge()
@@ -332,17 +324,13 @@ class TestLLMJudge:
         with pytest.raises(TypeError, match="abstract"):
 
             class IncompleteJudge(LLMJudge):  # type: ignore[abstract]
-                async def evaluate_relevance(
-                    self, _query: str, _response: str
-                ) -> JudgeResult:
+                async def evaluate_relevance(self, _query: str, _response: str) -> JudgeResult:
                     return JudgeResult(score=1.0)
 
                 async def extract_claims(self, _response: str) -> ClaimsResult:
                     return ClaimsResult(claims=[])
 
-                async def verify_claim(
-                    self, _claim: str, _context: list[str]
-                ) -> ClaimVerdict:
+                async def verify_claim(self, _claim: str, _context: list[str]) -> ClaimVerdict:
                     return ClaimVerdict(verdict="SUPPORTED")
 
             IncompleteJudge()
@@ -361,9 +349,7 @@ class TestLLMJudge:
                 async def extract_claims(self, _response: str) -> ClaimsResult:
                     return ClaimsResult(claims=[])
 
-                async def verify_claim(
-                    self, _claim: str, _context: list[str]
-                ) -> ClaimVerdict:
+                async def verify_claim(self, _claim: str, _context: list[str]) -> ClaimVerdict:
                     return ClaimVerdict(verdict="SUPPORTED")
 
             IncompleteJudge()
@@ -379,14 +365,10 @@ class TestLLMJudge:
                 ) -> JudgeResult:
                     return JudgeResult(score=1.0)
 
-                async def evaluate_relevance(
-                    self, _query: str, _response: str
-                ) -> JudgeResult:
+                async def evaluate_relevance(self, _query: str, _response: str) -> JudgeResult:
                     return JudgeResult(score=1.0)
 
-                async def verify_claim(
-                    self, _claim: str, _context: list[str]
-                ) -> ClaimVerdict:
+                async def verify_claim(self, _claim: str, _context: list[str]) -> ClaimVerdict:
                     return ClaimVerdict(verdict="SUPPORTED")
 
             IncompleteJudge()
@@ -402,9 +384,7 @@ class TestLLMJudge:
                 ) -> JudgeResult:
                     return JudgeResult(score=1.0)
 
-                async def evaluate_relevance(
-                    self, _query: str, _response: str
-                ) -> JudgeResult:
+                async def evaluate_relevance(self, _query: str, _response: str) -> JudgeResult:
                     return JudgeResult(score=1.0)
 
                 async def extract_claims(self, _response: str) -> ClaimsResult:

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -236,11 +236,13 @@ class TestPromptTemplateFormatContext:
 
     def test_format_context_multiple_docs(self, template: PromptTemplate) -> None:
         """format_context should number and separate multiple documents."""
-        result = template.format_context([
-            "First document.",
-            "Second document.",
-            "Third document.",
-        ])
+        result = template.format_context(
+            [
+                "First document.",
+                "Second document.",
+                "Third document.",
+            ]
+        )
         assert "Document 1:" in result
         assert "Document 2:" in result
         assert "Document 3:" in result

--- a/tests/unit/test_relevance_evaluator.py
+++ b/tests/unit/test_relevance_evaluator.py
@@ -1,0 +1,393 @@
+"""Unit tests for RelevanceEvaluator.
+
+Tests follow the acceptance criteria from Issue #7:
+- Score passes through from judge
+- Reasoning included in result
+- Threshold-based pass/fail works correctly
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ragaliq.core.evaluator import EvaluationResult
+from ragaliq.core.test_case import RAGTestCase
+from ragaliq.evaluators.relevance import RelevanceEvaluator
+from ragaliq.judges.base import JudgeResult, LLMJudge
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_judge() -> MagicMock:
+    """Create a mock LLM judge with relevance evaluation."""
+    judge = MagicMock(spec=LLMJudge)
+    judge.evaluate_relevance = AsyncMock(
+        return_value=JudgeResult(
+            score=0.9,
+            reasoning="Response directly answers the query.",
+            tokens_used=150,
+        )
+    )
+    return judge
+
+
+@pytest.fixture
+def relevant_test_case() -> RAGTestCase:
+    """A test case where response is relevant to the query."""
+    return RAGTestCase(
+        id="relevant_001",
+        name="Relevant Response",
+        query="What is the capital of France?",
+        context=["The capital city of France is Paris."],
+        response="The capital of France is Paris.",
+    )
+
+
+@pytest.fixture
+def irrelevant_test_case() -> RAGTestCase:
+    """A test case where response is off-topic from the query."""
+    return RAGTestCase(
+        id="irrelevant_001",
+        name="Irrelevant Response",
+        query="What is the capital of France?",
+        context=["The capital city of France is Paris."],
+        response="Python is a popular programming language used for data science.",
+    )
+
+
+# =============================================================================
+# Test Class Attributes
+# =============================================================================
+
+
+class TestRelevanceEvaluatorAttributes:
+    """Tests for evaluator class attributes and initialization."""
+
+    def test_has_required_name(self) -> None:
+        """Evaluator must have 'relevance' as name."""
+        evaluator = RelevanceEvaluator()
+        assert evaluator.name == "relevance"
+
+    def test_has_description(self) -> None:
+        """Evaluator must have a meaningful description."""
+        evaluator = RelevanceEvaluator()
+        assert evaluator.description
+        assert len(evaluator.description) > 10
+
+    def test_default_threshold_is_0_7(self) -> None:
+        """Default threshold should be 0.7 per base class."""
+        evaluator = RelevanceEvaluator()
+        assert evaluator.threshold == 0.7
+
+    def test_custom_threshold(self) -> None:
+        """Should accept custom threshold in constructor."""
+        evaluator = RelevanceEvaluator(threshold=0.9)
+        assert evaluator.threshold == 0.9
+
+    def test_repr(self) -> None:
+        """Should have a meaningful string representation."""
+        evaluator = RelevanceEvaluator(threshold=0.8)
+        assert "RelevanceEvaluator" in repr(evaluator)
+        assert "0.8" in repr(evaluator)
+
+
+# =============================================================================
+# Acceptance Criteria Tests
+# =============================================================================
+
+
+class TestRelevanceEvaluatorAcceptanceCriteria:
+    """Tests directly from Issue #7 acceptance criteria."""
+
+    @pytest.mark.asyncio
+    async def test_score_passes_through_from_judge(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """AC: Score passes through from judge."""
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=0.85,
+            reasoning="Mostly relevant.",
+            tokens_used=120,
+        )
+
+        evaluator = RelevanceEvaluator()
+        result = await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        assert result.score == 0.85
+
+    @pytest.mark.asyncio
+    async def test_reasoning_included_in_result(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """AC: Reasoning included in result."""
+        expected_reasoning = (
+            "Response directly addresses the user's question about France's capital."
+        )
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=0.95,
+            reasoning=expected_reasoning,
+            tokens_used=100,
+        )
+
+        evaluator = RelevanceEvaluator()
+        result = await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        assert result.reasoning == expected_reasoning
+
+
+# =============================================================================
+# Score Passthrough Tests
+# =============================================================================
+
+
+class TestRelevanceEvaluatorScorePassthrough:
+    """Tests that scores from the judge pass through correctly."""
+
+    @pytest.mark.asyncio
+    async def test_high_score_passes_through(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """High relevance score (1.0) passes through unchanged."""
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=1.0, reasoning="Perfectly relevant.", tokens_used=100
+        )
+
+        evaluator = RelevanceEvaluator()
+        result = await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        assert result.score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_low_score_passes_through(
+        self,
+        mock_judge: MagicMock,
+        irrelevant_test_case: RAGTestCase,
+    ) -> None:
+        """Low relevance score (0.1) passes through unchanged."""
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=0.1, reasoning="Mostly irrelevant.", tokens_used=100
+        )
+
+        evaluator = RelevanceEvaluator()
+        result = await evaluator.evaluate(irrelevant_test_case, mock_judge)
+
+        assert result.score == 0.1
+
+    @pytest.mark.asyncio
+    async def test_zero_score_passes_through(
+        self,
+        mock_judge: MagicMock,
+        irrelevant_test_case: RAGTestCase,
+    ) -> None:
+        """Zero relevance score (0.0) passes through unchanged."""
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=0.0, reasoning="Completely off-topic.", tokens_used=80
+        )
+
+        evaluator = RelevanceEvaluator()
+        result = await evaluator.evaluate(irrelevant_test_case, mock_judge)
+
+        assert result.score == 0.0
+
+
+# =============================================================================
+# Threshold Logic Tests
+# =============================================================================
+
+
+class TestRelevanceEvaluatorThresholdLogic:
+    """Tests for pass/fail based on configurable threshold."""
+
+    @pytest.mark.asyncio
+    async def test_score_at_threshold_passes(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """Score exactly at threshold (0.7) should pass."""
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=0.7, reasoning="Reasonably relevant.", tokens_used=100
+        )
+
+        evaluator = RelevanceEvaluator()  # default threshold=0.7
+        result = await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        assert result.score == 0.7
+        assert result.passed is True
+
+    @pytest.mark.asyncio
+    async def test_score_below_threshold_fails(
+        self,
+        mock_judge: MagicMock,
+        irrelevant_test_case: RAGTestCase,
+    ) -> None:
+        """Score below threshold should fail."""
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=0.4, reasoning="Partially relevant.", tokens_used=100
+        )
+
+        evaluator = RelevanceEvaluator()  # default threshold=0.7
+        result = await evaluator.evaluate(irrelevant_test_case, mock_judge)
+
+        assert result.score == 0.4
+        assert result.passed is False
+
+    @pytest.mark.asyncio
+    async def test_custom_threshold_applied(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """Custom threshold should be used for pass/fail."""
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=0.85, reasoning="Mostly relevant.", tokens_used=100
+        )
+
+        # 0.85 passes with default 0.7, but fails with 0.9
+        evaluator_default = RelevanceEvaluator()
+        result_default = await evaluator_default.evaluate(relevant_test_case, mock_judge)
+        assert result_default.passed is True
+
+        evaluator_strict = RelevanceEvaluator(threshold=0.9)
+        result_strict = await evaluator_strict.evaluate(relevant_test_case, mock_judge)
+        assert result_strict.passed is False
+
+
+# =============================================================================
+# Raw Response / Metadata Tests
+# =============================================================================
+
+
+class TestRelevanceEvaluatorRawResponse:
+    """Tests for judge metadata preserved in raw_response."""
+
+    @pytest.mark.asyncio
+    async def test_raw_response_contains_score(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """raw_response should contain the judge's score."""
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=0.92, reasoning="Very relevant.", tokens_used=130
+        )
+
+        evaluator = RelevanceEvaluator()
+        result = await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        assert result.raw_response["score"] == 0.92
+
+    @pytest.mark.asyncio
+    async def test_raw_response_contains_reasoning(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """raw_response should contain the judge's reasoning."""
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=0.92, reasoning="Very relevant.", tokens_used=130
+        )
+
+        evaluator = RelevanceEvaluator()
+        result = await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        assert result.raw_response["reasoning"] == "Very relevant."
+
+    @pytest.mark.asyncio
+    async def test_raw_response_contains_tokens_used(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """raw_response should contain tokens_used for cost tracking."""
+        mock_judge.evaluate_relevance.return_value = JudgeResult(
+            score=0.92, reasoning="Very relevant.", tokens_used=130
+        )
+
+        evaluator = RelevanceEvaluator()
+        result = await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        assert result.raw_response["tokens_used"] == 130
+
+
+# =============================================================================
+# Result Structure Tests
+# =============================================================================
+
+
+class TestRelevanceEvaluatorResultStructure:
+    """Tests for EvaluationResult structure compliance."""
+
+    @pytest.mark.asyncio
+    async def test_returns_evaluation_result(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """evaluate() should return EvaluationResult instance."""
+        evaluator = RelevanceEvaluator()
+        result = await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        assert isinstance(result, EvaluationResult)
+
+    @pytest.mark.asyncio
+    async def test_evaluator_name_in_result(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """Result should contain evaluator name 'relevance'."""
+        evaluator = RelevanceEvaluator()
+        result = await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        assert result.evaluator_name == "relevance"
+
+
+# =============================================================================
+# Judge Interaction Tests
+# =============================================================================
+
+
+class TestRelevanceEvaluatorJudgeInteraction:
+    """Tests that the evaluator calls the judge correctly."""
+
+    @pytest.mark.asyncio
+    async def test_calls_judge_with_query_and_response(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """evaluate() should call judge.evaluate_relevance with correct args."""
+        evaluator = RelevanceEvaluator()
+        await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        mock_judge.evaluate_relevance.assert_called_once_with(
+            query=relevant_test_case.query,
+            response=relevant_test_case.response,
+        )
+
+    @pytest.mark.asyncio
+    async def test_does_not_call_other_judge_methods(
+        self,
+        mock_judge: MagicMock,
+        relevant_test_case: RAGTestCase,
+    ) -> None:
+        """evaluate() should only call evaluate_relevance, not other methods."""
+        evaluator = RelevanceEvaluator()
+        await evaluator.evaluate(relevant_test_case, mock_judge)
+
+        # Should NOT call faithfulness-related methods
+        mock_judge.evaluate_faithfulness.assert_not_called()
+        mock_judge.extract_claims.assert_not_called()
+        mock_judge.verify_claim.assert_not_called()


### PR DESCRIPTION
Closes #7

## Summary

- **RelevanceEvaluator** (`src/ragaliq/evaluators/relevance.py`): Thin adapter over `judge.evaluate_relevance()` that conforms to the `Evaluator` interface with threshold-based pass/fail semantics
- **18 unit tests** (`tests/unit/test_relevance_evaluator.py`): Score passthrough, reasoning inclusion, threshold logic, raw response metadata, judge interaction verification
- **Decision document** (`docs/decisions/task_7_analysis.md`): Context, proposed solution, SOLID principles, alternatives considered
- **Exports updated** in `evaluators/__init__.py`
- **Ruff formatting** applied to existing files (no semantic changes)

## Design

The simplest evaluator in the pipeline — delegates entirely to the judge and adapts `JudgeResult` → `EvaluationResult`. Follows the Adapter pattern established by FaithfulnessEvaluator but without multi-step orchestration.

## Quality Gates

- `hatch run lint` — clean (pre-existing issues only)
- `hatch run typecheck` — clean (pre-existing issue only)
- `hatch run test` — 169 passed, 1 skipped
- `relevance.py` — 100% code coverage

## Test plan

- [x] Score passes through from judge unchanged (0.0, 0.1, 0.85, 1.0)
- [x] Judge reasoning appears in `EvaluationResult.reasoning`
- [x] Threshold-based pass/fail works (default 0.7, custom thresholds)
- [x] `raw_response` preserves score, reasoning, tokens_used
- [x] Only `evaluate_relevance` is called (not faithfulness/claims methods)
- [x] Correct `evaluator_name` and `EvaluationResult` type returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)