### PR TITLE
[FEAT] Implement evaluator registry, CLI entry point, and critical fixes

### DIFF
--- a/src/ragaliq/cli/main.py
+++ b/src/ragaliq/cli/main.py
@@ -1,0 +1,53 @@
+"""CLI entry point for RagaliQ."""
+
+
+import typer
+
+import ragaliq
+
+app = typer.Typer(no_args_is_help=True)
+
+
+def version_callback(value: bool) -> None:
+    """Display version and exit."""
+    if value:
+        typer.echo(f"RagaliQ version {ragaliq.__version__}")
+        raise typer.Exit()
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        None,
+        "--version",
+        "-V",
+        help="Show version and exit",
+        callback=version_callback,
+        is_eager=True,
+    ),
+) -> None:
+    """RagaliQ - LLM Testing Framework for RAG Systems."""
+    pass
+
+
+@app.command()
+def evaluate() -> None:
+    """
+    Evaluate RAG test cases.
+
+    This command is not yet implemented. For now, use RagaliQ as a library:
+
+        from ragaliq import RagaliQ, RAGTestCase
+
+        tester = RagaliQ(judge="claude")
+        test_case = RAGTestCase(...)
+        result = tester.evaluate(test_case)
+    """
+    typer.echo("The 'evaluate' command is not yet implemented.")
+    typer.echo("Please use RagaliQ as a library for now.")
+    typer.echo("\nSee: https://github.com/dariero/ragaliq for usage examples.")
+    raise typer.Exit(code=1)
+
+
+if __name__ == "__main__":
+    app()

--- a/src/ragaliq/core/evaluator.py
+++ b/src/ragaliq/core/evaluator.py
@@ -20,6 +20,7 @@ class EvaluationResult(BaseModel):
         passed: Whether the score meets the threshold.
         reasoning: Human-readable explanation of the score.
         raw_response: Raw response from the LLM judge for debugging.
+        tokens_used: Total tokens consumed by this evaluation.
     """
 
     evaluator_name: str = Field(..., description="Name of the evaluator")
@@ -27,6 +28,7 @@ class EvaluationResult(BaseModel):
     passed: bool = Field(..., description="Whether threshold was met")
     reasoning: str = Field(default="", description="Explanation of the score")
     raw_response: dict[str, Any] = Field(default_factory=dict, description="Raw judge response")
+    tokens_used: int = Field(default=0, ge=0, description="Total tokens consumed")
 
     model_config = {"frozen": True, "extra": "forbid"}
 

--- a/src/ragaliq/evaluators/__init__.py
+++ b/src/ragaliq/evaluators/__init__.py
@@ -1,11 +1,19 @@
 """Evaluators package for RagaliQ."""
 
+from ragaliq.core.evaluator import Evaluator
 from ragaliq.evaluators.faithfulness import FaithfulnessEvaluator
 from ragaliq.evaluators.hallucination import HallucinationEvaluator
 from ragaliq.evaluators.relevance import RelevanceEvaluator
+
+EVALUATOR_REGISTRY: dict[str, type[Evaluator]] = {
+    "faithfulness": FaithfulnessEvaluator,
+    "relevance": RelevanceEvaluator,
+    "hallucination": HallucinationEvaluator,
+}
 
 __all__ = [
     "FaithfulnessEvaluator",
     "HallucinationEvaluator",
     "RelevanceEvaluator",
+    "EVALUATOR_REGISTRY",
 ]

--- a/src/ragaliq/evaluators/faithfulness.py
+++ b/src/ragaliq/evaluators/faithfulness.py
@@ -84,6 +84,7 @@ class FaithfulnessEvaluator(Evaluator):
         # Step 1: Extract atomic claims from the response
         claims_result = await judge.extract_claims(test_case.response)
         claims = claims_result.claims
+        total_tokens = claims_result.tokens_used
 
         # Handle empty claims edge case: vacuously faithful
         if not claims:
@@ -97,6 +98,7 @@ class FaithfulnessEvaluator(Evaluator):
                     "total_claims": 0,
                     "supported_claims": 0,
                 },
+                tokens_used=total_tokens,
             )
 
         # Step 2: Verify each claim against the context
@@ -105,6 +107,7 @@ class FaithfulnessEvaluator(Evaluator):
 
         for claim in claims:
             verdict = await judge.verify_claim(claim, test_case.context)
+            total_tokens += verdict.tokens_used
 
             claim_details.append(
                 {
@@ -134,6 +137,7 @@ class FaithfulnessEvaluator(Evaluator):
                 "total_claims": total_claims,
                 "supported_claims": supported_count,
             },
+            tokens_used=total_tokens,
         )
 
     def _build_reasoning(self, supported: int, total: int) -> str:

--- a/src/ragaliq/evaluators/hallucination.py
+++ b/src/ragaliq/evaluators/hallucination.py
@@ -89,6 +89,7 @@ class HallucinationEvaluator(Evaluator):
         # Step 1: Extract atomic claims from the response
         claims_result = await judge.extract_claims(test_case.response)
         claims = claims_result.claims
+        total_tokens = claims_result.tokens_used
 
         # Handle empty claims edge case: no claims means no hallucinations
         if not claims:
@@ -103,6 +104,7 @@ class HallucinationEvaluator(Evaluator):
                     "hallucinated_claims": [],
                     "hallucination_count": 0,
                 },
+                tokens_used=total_tokens,
             )
 
         # Step 2: Verify each claim and classify hallucinations
@@ -111,6 +113,7 @@ class HallucinationEvaluator(Evaluator):
 
         for claim in claims:
             verdict = await judge.verify_claim(claim, test_case.context)
+            total_tokens += verdict.tokens_used
 
             detail = {
                 "claim": claim,
@@ -142,6 +145,7 @@ class HallucinationEvaluator(Evaluator):
                 "hallucinated_claims": hallucinated,
                 "hallucination_count": hallucination_count,
             },
+            tokens_used=total_tokens,
         )
 
     def _build_reasoning(self, hallucinated: int, total: int) -> str:

--- a/src/ragaliq/evaluators/relevance.py
+++ b/src/ragaliq/evaluators/relevance.py
@@ -88,4 +88,5 @@ class RelevanceEvaluator(Evaluator):
                 "reasoning": judge_result.reasoning,
                 "tokens_used": judge_result.tokens_used,
             },
+            tokens_used=judge_result.tokens_used,
         )

--- a/src/ragaliq/judges/base.py
+++ b/src/ragaliq/judges/base.py
@@ -57,12 +57,14 @@ class ClaimVerdict(BaseModel):
     Attributes:
         verdict: Three-way classification of claim support.
         evidence: Quote from context or explanation supporting the verdict.
+        tokens_used: Tokens consumed by the verification call.
     """
 
     verdict: Literal["SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO"] = Field(
         ..., description="Three-way verdict on claim support"
     )
     evidence: str = Field(default="", description="Supporting quote or explanation")
+    tokens_used: int = Field(default=0, ge=0, description="Tokens used")
 
     model_config = {"frozen": True, "extra": "forbid"}
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,54 @@
+"""Unit tests for RagaliQ CLI entry point."""
+
+from typer.testing import CliRunner
+
+import ragaliq
+from ragaliq.cli.main import app
+
+runner = CliRunner()
+
+
+class TestCLIVersion:
+    """Test CLI version flag."""
+
+    def test_version_flag_long(self):
+        """--version flag shows version and exits."""
+        result = runner.invoke(app, ["--version"])
+
+        assert result.exit_code == 0
+        assert f"RagaliQ version {ragaliq.__version__}" in result.stdout
+
+    def test_version_flag_short(self):
+        """-V flag shows version and exits."""
+        result = runner.invoke(app, ["-V"])
+
+        assert result.exit_code == 0
+        assert f"RagaliQ version {ragaliq.__version__}" in result.stdout
+
+
+class TestCLINoArgs:
+    """Test CLI with no arguments."""
+
+    def test_no_args_shows_help(self):
+        """Running with no args shows help message."""
+        result = runner.invoke(app, [])
+
+        # Typer shows help when no_args_is_help=True
+        assert "Usage:" in result.stdout or "Commands:" in result.stdout
+
+
+class TestEvaluateCommand:
+    """Test evaluate command placeholder."""
+
+    def test_evaluate_command_exits_with_error(self):
+        """evaluate command prints placeholder and exits with code 1."""
+        result = runner.invoke(app, ["evaluate"])
+
+        assert result.exit_code == 1
+        assert "not yet implemented" in result.stdout
+
+    def test_evaluate_command_shows_library_usage(self):
+        """evaluate command suggests using RagaliQ as a library."""
+        result = runner.invoke(app, ["evaluate"])
+
+        assert "library" in result.stdout.lower()

--- a/tests/unit/test_relevance_evaluator.py
+++ b/tests/unit/test_relevance_evaluator.py
@@ -121,6 +121,7 @@ class TestRelevanceEvaluatorAcceptanceCriteria:
         result = await evaluator.evaluate(relevant_test_case, mock_judge)
 
         assert result.score == 0.85
+        assert result.tokens_used == 120
 
     @pytest.mark.asyncio
     async def test_reasoning_included_in_result(


### PR DESCRIPTION
## Summary

This PR implements critical infrastructure improvements and fixes multiple blockers identified in the codebase audit. The changes span evaluator initialization, token accounting, API retry logic, concurrency control, and CLI packaging.

## Changes

### 🎯 Evaluator Registry (Addresses #11)
- Added `EVALUATOR_REGISTRY` to `src/ragaliq/evaluators/__init__.py`
- Wired registry into `RagaliQ._init_evaluators()` replacing `NotImplementedError` stub
- Evaluators now lazily initialized from registry with custom threshold support
- Tests cover: default names, custom names, unknown evaluators, threshold application, idempotency

### 🖥️ CLI Entry Point (Addresses #13)  
- Created `src/ragaliq/cli/main.py` with Typer app
- Implemented `--version` / `-V` flag reading from `ragaliq.__version__`
- Added placeholder `evaluate` command with helpful usage guidance
- Fixes packaging break (missing main.py)
- Comprehensive CLI tests in `tests/unit/test_cli.py`

### 💰 Token Accounting Fix
- Added typed `tokens_used: int` field to `EvaluationResult` (replaces dict scraping)
- Added `tokens_used: int` field to `ClaimVerdict` 
- Updated `judges/claude.py` to capture and propagate tokens (line 406)
- All evaluators now accumulate tokens correctly:
  - `FaithfulnessEvaluator`: extraction + all verifications
  - `HallucinationEvaluator`: extraction + all verifications
  - `RelevanceEvaluator`: passthrough from judge
- Updated `runner.py` to use typed field instead of `raw_response.get("tokens_used", 0)`

### 🔄 Retry/Backoff for 429/5xx
- Added `_is_retryable_api_error()` helper to identify retryable status codes
- Updated `@retry` decorator to retry 429 (rate limit) and 5xx (server errors)
- Split exception handling: re-raise retryable errors, wrap others as `JudgeAPIError`
- Updated 4 caller methods to catch both `APIConnectionError` and `APIStatusError`
- Tests verify: 429 retried 3x, 500 retried, 400 not retried, transient 429 recovery

### ⚡ Bounded Concurrency
- Added `max_concurrency: int = 5` parameter to `RagaliQ.__init__()`
- Implemented `asyncio.Semaphore` in `evaluate_batch_async()` to prevent unbounded parallelism
- Added optional `max_concurrency` override parameter for batch operations
- Tests verify concurrency limits are respected

## Testing

✅ **222 tests passing** (1 skipped integration test)
- Added 18 new tests across runner, CLI, and judge modules
- Updated evaluator tests to assert on `tokens_used` field
- All quality gates pass (lint/typecheck issues are pre-existing and documented)

## Files Changed (15)

**Core:**
- `src/ragaliq/core/evaluator.py` - Added tokens_used field
- `src/ragaliq/core/runner.py` - Evaluator init, token accounting, concurrency
- `src/ragaliq/evaluators/__init__.py` - Registry implementation

**Judges:**
- `src/ragaliq/judges/base.py` - Added tokens_used to ClaimVerdict
- `src/ragaliq/judges/claude.py` - Retry logic, token capture

**Evaluators:**
- `src/ragaliq/evaluators/{faithfulness,hallucination,relevance}.py` - Token accumulation

**CLI:**
- `src/ragaliq/cli/main.py` - **NEW** CLI entry point

**Tests:**
- `tests/unit/test_runner.py` - Registry + concurrency tests
- `tests/unit/test_cli.py` - **NEW** CLI tests
- `tests/unit/test_claude_judge.py` - Retry tests
- `tests/unit/test_{faithfulness,hallucination,relevance}_evaluator.py` - Token assertions

## Verification

```bash
hatch run format  # 3 files reformatted
hatch run lint    # Only pre-existing issues
hatch run typecheck  # Only pre-existing issue
hatch run test    # 222 passed ✅
python -c "from ragaliq.cli.main import app"  # Import successful ✅
```

## Related Issues

Partially addresses:
- #11 - Evaluator Registry (core functionality implemented)
- #13 - CLI Foundation (entry point created, full command set deferred)

---

**Commits:**
- 8b69256 [FEAT] Implement evaluator registry, CLI entry point, and critical fixes

**Quality Gates:** ✅ All tests passing (pre-existing lint/typecheck issues documented in MEMORY.md)

🤖 Generated with Claude Code