### PR TITLE
[FEAT #13] Implement CLI foundation with run, list-evaluators, validate, version commands

### DIFF
--- a/src/ragaliq/cli/main.py
+++ b/src/ragaliq/cli/main.py
@@ -1,6 +1,12 @@
 """CLI entry point for RagaliQ."""
 
+from __future__ import annotations
+
+from pathlib import Path
+
 import typer
+from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
+from rich.table import Table
 
 import ragaliq
 
@@ -20,32 +26,178 @@ def main(
         None,
         "--version",
         "-V",
-        help="Show version and exit",
+        help="Show version and exit.",
         callback=version_callback,
         is_eager=True,
     ),
 ) -> None:
     """RagaliQ - LLM Testing Framework for RAG Systems."""
-    pass
 
 
-@app.command()
-def evaluate() -> None:
+@app.command("run")
+def run(
+    dataset: Path = typer.Argument(..., help="Path to dataset file (JSON, YAML, or CSV)."),
+    evaluator: list[str] | None = typer.Option(
+        None,
+        "--evaluator",
+        "-e",
+        help="Evaluators to run. Can be specified multiple times. Defaults to faithfulness and relevance.",
+    ),
+    threshold: float = typer.Option(
+        0.7, "--threshold", "-t", help="Pass/fail threshold (0.0–1.0)."
+    ),
+    judge: str = typer.Option("claude", "--judge", "-j", help="LLM judge to use."),
+    fail_fast: bool = typer.Option(False, "--fail-fast", help="Stop on first evaluator error."),
+) -> None:
+    """Run evaluations against a dataset."""
+    from rich.console import Console
+
+    from ragaliq import RagaliQ
+    from ragaliq.datasets import DatasetLoader, DatasetLoadError
+
+    console = Console()
+
+    try:
+        dataset_obj = DatasetLoader.load(dataset)
+    except DatasetLoadError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    test_cases = dataset_obj.test_cases
+    total = len(test_cases)
+    typer.echo(f"\nRagaliQ — {total} test case{'s' if total != 1 else ''} loaded\n")
+
+    runner_obj = RagaliQ(
+        judge=judge,
+        evaluators=evaluator if evaluator else None,
+        default_threshold=threshold,
+        fail_fast=fail_fast,
+    )
+
+    results = []
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        TaskProgressColumn(),
+        console=console,
+        transient=True,
+    ) as progress:
+        task_id = progress.add_task("Evaluating...", total=total)
+        for tc in test_cases:
+            result = runner_obj.evaluate(tc)
+            results.append(result)
+            progress.advance(task_id)
+
+    _print_results_table(results, console)
+
+    passed = sum(1 for r in results if r.passed)
+    failed = total - passed
+    if failed:
+        typer.echo(f"\nSummary: {passed}/{total} passed, {failed} failed")
+        raise typer.Exit(code=1)
+    else:
+        typer.echo(f"\nSummary: {passed}/{total} passed")
+
+
+def _print_results_table(results: list, console: object) -> None:
+    """Render evaluation results as a Rich table.
+
+    Args:
+        results: List of RAGTestResult objects.
+        console: Rich Console to render to.
     """
-    Evaluate RAG test cases.
+    from rich.console import Console
 
-    This command is not yet implemented. For now, use RagaliQ as a library:
+    from ragaliq.core.test_case import EvalStatus
 
-        from ragaliq import RagaliQ, RAGTestCase
+    if not isinstance(console, Console):
+        return
 
-        tester = RagaliQ(judge="claude")
-        test_case = RAGTestCase(...)
-        result = tester.evaluate(test_case)
-    """
-    typer.echo("The 'evaluate' command is not yet implemented.")
-    typer.echo("Please use RagaliQ as a library for now.")
-    typer.echo("\nSee: https://github.com/dariero/ragaliq for usage examples.")
-    raise typer.Exit(code=1)
+    table = Table(title="Evaluation Results", show_lines=True)
+    table.add_column("Test Case", style="bold")
+    table.add_column("Status", justify="center")
+
+    evaluator_names: list[str] = []
+    if results:
+        evaluator_names = sorted(results[0].scores.keys())
+
+    for name in evaluator_names:
+        table.add_column(name.replace("_", " ").title(), justify="center")
+
+    status_map = {
+        EvalStatus.PASSED: "[green]PASS[/green]",
+        EvalStatus.FAILED: "[red]FAIL[/red]",
+        EvalStatus.ERROR: "[yellow]ERROR[/yellow]",
+        EvalStatus.SKIPPED: "[dim]SKIP[/dim]",
+    }
+
+    for result in results:
+        status_str = status_map.get(result.status, str(result.status))
+        score_cells = []
+        for name in evaluator_names:
+            score = result.scores.get(name)
+            if score is None:
+                score_cells.append("—")
+            elif score >= 0.7:
+                score_cells.append(f"[green]{score:.2f}[/green]")
+            else:
+                score_cells.append(f"[red]{score:.2f}[/red]")
+        table.add_row(result.test_case.name, status_str, *score_cells)
+
+    console.print(table)
+
+
+@app.command("list-evaluators")
+def list_evaluators_cmd() -> None:
+    """List all available evaluators."""
+    from rich.console import Console
+
+    import ragaliq.evaluators  # noqa: F401 — triggers registration of built-ins
+    from ragaliq.evaluators import get_evaluator, list_evaluators
+
+    console = Console()
+    names = list_evaluators()
+
+    if not names:
+        typer.echo("No evaluators registered.")
+        return
+
+    table = Table(title="Available Evaluators", show_lines=True)
+    table.add_column("Name", style="bold cyan")
+    table.add_column("Description")
+    table.add_column("Default Threshold", justify="center")
+
+    for name in names:
+        cls = get_evaluator(name)
+        description = getattr(cls, "description", "—")
+        threshold = getattr(cls, "threshold", 0.7)
+        table.add_row(name, description, str(threshold))
+
+    console.print(table)
+
+
+@app.command("validate")
+def validate(
+    dataset: Path = typer.Argument(..., help="Path to dataset file to validate."),
+) -> None:
+    """Validate dataset schema without running evaluations."""
+    from ragaliq.datasets import DatasetLoader, DatasetLoadError
+
+    try:
+        dataset_obj = DatasetLoader.load(dataset)
+    except DatasetLoadError as exc:
+        typer.echo(f"Validation failed: {exc}", err=True)
+        raise typer.Exit(code=1) from None
+
+    total = len(dataset_obj.test_cases)
+    typer.echo(f"Valid — {total} test case{'s' if total != 1 else ''} found in {dataset}")
+
+
+@app.command("version")
+def version_cmd() -> None:
+    """Show version information."""
+    typer.echo(f"RagaliQ version {ragaliq.__version__}")
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,5 +1,7 @@
 """Unit tests for RagaliQ CLI entry point."""
 
+from unittest.mock import MagicMock, patch
+
 from typer.testing import CliRunner
 
 import ragaliq
@@ -16,14 +18,14 @@ class TestCLIVersion:
         result = runner.invoke(app, ["--version"])
 
         assert result.exit_code == 0
-        assert f"RagaliQ version {ragaliq.__version__}" in result.stdout
+        assert f"RagaliQ version {ragaliq.__version__}" in result.output
 
     def test_version_flag_short(self):
         """-V flag shows version and exits."""
         result = runner.invoke(app, ["-V"])
 
         assert result.exit_code == 0
-        assert f"RagaliQ version {ragaliq.__version__}" in result.stdout
+        assert f"RagaliQ version {ragaliq.__version__}" in result.output
 
 
 class TestCLINoArgs:
@@ -33,22 +35,241 @@ class TestCLINoArgs:
         """Running with no args shows help message."""
         result = runner.invoke(app, [])
 
-        # Typer shows help when no_args_is_help=True
-        assert "Usage:" in result.stdout or "Commands:" in result.stdout
+        assert "Usage:" in result.output or "Commands:" in result.output
 
 
-class TestEvaluateCommand:
-    """Test evaluate command placeholder."""
+class TestVersionCommand:
+    """Test version subcommand."""
 
-    def test_evaluate_command_exits_with_error(self):
-        """evaluate command prints placeholder and exits with code 1."""
-        result = runner.invoke(app, ["evaluate"])
+    def test_version_command_shows_version(self):
+        """version command outputs the current version."""
+        result = runner.invoke(app, ["version"])
+
+        assert result.exit_code == 0
+        assert ragaliq.__version__ in result.output
+
+
+class TestListEvaluatorsCommand:
+    """Test list-evaluators command."""
+
+    def test_exits_zero(self):
+        """list-evaluators exits successfully."""
+        result = runner.invoke(app, ["list-evaluators"])
+
+        assert result.exit_code == 0
+
+    def test_shows_built_in_evaluator_faithfulness(self):
+        """list-evaluators includes faithfulness in output."""
+        result = runner.invoke(app, ["list-evaluators"])
+
+        assert "faithfulness" in result.output
+
+    def test_shows_built_in_evaluator_relevance(self):
+        """list-evaluators includes relevance in output."""
+        result = runner.invoke(app, ["list-evaluators"])
+
+        assert "relevance" in result.output
+
+    def test_shows_description_heading(self):
+        """list-evaluators shows a Description column heading."""
+        result = runner.invoke(app, ["list-evaluators"])
+
+        assert "Description" in result.output
+
+
+class TestValidateCommand:
+    """Test validate command."""
+
+    def _mock_dataset(self, n: int = 2) -> MagicMock:
+        """Return a minimal mock DatasetSchema with n test cases."""
+        dataset = MagicMock()
+        dataset.test_cases = [MagicMock() for _ in range(n)]
+        return dataset
+
+    def test_valid_dataset_exits_zero(self):
+        """validate exits 0 for a loadable dataset."""
+        with patch("ragaliq.datasets.DatasetLoader.load", return_value=self._mock_dataset(2)):
+            result = runner.invoke(app, ["validate", "dataset.json"])
+
+        assert result.exit_code == 0
+
+    def test_valid_dataset_shows_count(self):
+        """validate reports the number of test cases found."""
+        with patch("ragaliq.datasets.DatasetLoader.load", return_value=self._mock_dataset(3)):
+            result = runner.invoke(app, ["validate", "dataset.json"])
+
+        assert "3 test cases" in result.output
+
+    def test_singular_when_one_test_case(self):
+        """validate uses singular 'test case' when there is exactly one."""
+        with patch("ragaliq.datasets.DatasetLoader.load", return_value=self._mock_dataset(1)):
+            result = runner.invoke(app, ["validate", "dataset.json"])
+
+        assert "1 test case" in result.output
+        assert "1 test cases" not in result.output
+
+    def test_invalid_dataset_exits_one(self):
+        """validate exits 1 when the dataset fails to load."""
+        from ragaliq.datasets import DatasetLoadError
+
+        with patch(
+            "ragaliq.datasets.DatasetLoader.load",
+            side_effect=DatasetLoadError("unsupported format"),
+        ):
+            result = runner.invoke(app, ["validate", "bad.json"])
 
         assert result.exit_code == 1
-        assert "not yet implemented" in result.stdout
 
-    def test_evaluate_command_shows_library_usage(self):
-        """evaluate command suggests using RagaliQ as a library."""
-        result = runner.invoke(app, ["evaluate"])
+    def test_invalid_dataset_shows_error_message(self):
+        """validate shows an error message when loading fails."""
+        from ragaliq.datasets import DatasetLoadError
 
-        assert "library" in result.stdout.lower()
+        with patch(
+            "ragaliq.datasets.DatasetLoader.load",
+            side_effect=DatasetLoadError("unsupported format"),
+        ):
+            result = runner.invoke(app, ["validate", "bad.json"])
+
+        assert "Validation failed" in result.output
+
+    def test_missing_path_argument_exits_nonzero(self):
+        """validate requires a dataset path argument."""
+        result = runner.invoke(app, ["validate"])
+
+        assert result.exit_code != 0
+
+
+class TestRunCommand:
+    """Test run command."""
+
+    def _mock_passing_result(self, name: str = "test-1") -> MagicMock:
+        """Build a mock RAGTestResult that passes."""
+        from ragaliq.core.test_case import EvalStatus
+
+        tc = MagicMock()
+        tc.name = name
+
+        result = MagicMock()
+        result.passed = True
+        result.status = EvalStatus.PASSED
+        result.scores = {"faithfulness": 0.9, "relevance": 0.85}
+        result.test_case = tc
+        return result
+
+    def _mock_failing_result(self, name: str = "test-2") -> MagicMock:
+        """Build a mock RAGTestResult that fails."""
+        from ragaliq.core.test_case import EvalStatus
+
+        tc = MagicMock()
+        tc.name = name
+
+        result = MagicMock()
+        result.passed = False
+        result.status = EvalStatus.FAILED
+        result.scores = {"faithfulness": 0.3, "relevance": 0.4}
+        result.test_case = tc
+        return result
+
+    def test_all_passing_exits_zero(self):
+        """run exits 0 when every test case passes."""
+        mock_dataset = MagicMock()
+        mock_dataset.test_cases = [MagicMock()]
+
+        with (
+            patch("ragaliq.datasets.DatasetLoader.load", return_value=mock_dataset),
+            patch("ragaliq.RagaliQ") as mock_cls,
+        ):
+            mock_cls.return_value.evaluate.return_value = self._mock_passing_result()
+            result = runner.invoke(app, ["run", "dataset.json"])
+
+        assert result.exit_code == 0
+
+    def test_any_failure_exits_one(self):
+        """run exits 1 when at least one test case fails."""
+        mock_dataset = MagicMock()
+        mock_dataset.test_cases = [MagicMock()]
+
+        with (
+            patch("ragaliq.datasets.DatasetLoader.load", return_value=mock_dataset),
+            patch("ragaliq.RagaliQ") as mock_cls,
+        ):
+            mock_cls.return_value.evaluate.return_value = self._mock_failing_result()
+            result = runner.invoke(app, ["run", "dataset.json"])
+
+        assert result.exit_code == 1
+
+    def test_dataset_load_error_exits_one(self):
+        """run exits 1 when the dataset fails to load."""
+        from ragaliq.datasets import DatasetLoadError
+
+        with patch(
+            "ragaliq.datasets.DatasetLoader.load",
+            side_effect=DatasetLoadError("file not found"),
+        ):
+            result = runner.invoke(app, ["run", "missing.json"])
+
+        assert result.exit_code == 1
+
+    def test_dataset_load_error_shows_message(self):
+        """run shows an error message when dataset loading fails."""
+        from ragaliq.datasets import DatasetLoadError
+
+        with patch(
+            "ragaliq.datasets.DatasetLoader.load",
+            side_effect=DatasetLoadError("file not found"),
+        ):
+            result = runner.invoke(app, ["run", "missing.json"])
+
+        assert "Error" in result.output
+
+    def test_evaluator_option_forwarded_to_runner(self):
+        """--evaluator option is forwarded to RagaliQ constructor."""
+        mock_result = self._mock_passing_result()
+        mock_result.scores = {"relevance": 0.9}
+        mock_dataset = MagicMock()
+        mock_dataset.test_cases = [MagicMock()]
+
+        with (
+            patch("ragaliq.datasets.DatasetLoader.load", return_value=mock_dataset),
+            patch("ragaliq.RagaliQ") as mock_cls,
+        ):
+            mock_cls.return_value.evaluate.return_value = mock_result
+            runner.invoke(app, ["run", "dataset.json", "--evaluator", "relevance"])
+
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["evaluators"] == ["relevance"]
+
+    def test_threshold_option_forwarded_to_runner(self):
+        """--threshold option is forwarded to RagaliQ constructor."""
+        mock_dataset = MagicMock()
+        mock_dataset.test_cases = [MagicMock()]
+
+        with (
+            patch("ragaliq.datasets.DatasetLoader.load", return_value=mock_dataset),
+            patch("ragaliq.RagaliQ") as mock_cls,
+        ):
+            mock_cls.return_value.evaluate.return_value = self._mock_passing_result()
+            runner.invoke(app, ["run", "dataset.json", "--threshold", "0.9"])
+
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["default_threshold"] == 0.9
+
+    def test_summary_shows_pass_count(self):
+        """run outputs a summary line with the pass/total count."""
+        mock_dataset = MagicMock()
+        mock_dataset.test_cases = [MagicMock()]
+
+        with (
+            patch("ragaliq.datasets.DatasetLoader.load", return_value=mock_dataset),
+            patch("ragaliq.RagaliQ") as mock_cls,
+        ):
+            mock_cls.return_value.evaluate.return_value = self._mock_passing_result()
+            result = runner.invoke(app, ["run", "dataset.json"])
+
+        assert "1/1 passed" in result.output
+
+    def test_missing_path_argument_exits_nonzero(self):
+        """run requires a dataset path argument."""
+        result = runner.invoke(app, ["run"])
+
+        assert result.exit_code != 0

--- a/tests/unit/test_datasets.py
+++ b/tests/unit/test_datasets.py
@@ -215,9 +215,7 @@ class TestDatasetLoaderCSV:
         """Test CSV file missing required columns."""
         invalid_csv = tmp_path / "missing_column.csv"
         invalid_csv.write_text("id,name,query\ntest_1,Test,Query?")
-        with pytest.raises(
-            DatasetLoadError, match="missing required columns:"
-        ):
+        with pytest.raises(DatasetLoadError, match="missing required columns:"):
             DatasetLoader.load(invalid_csv)
 
     def test_load_csv_empty_after_header(self, tmp_path: Path):


### PR DESCRIPTION
Closes #13

## Changes

- **`cli/main.py`**: Replaced stub with four working Typer commands:
  - `ragaliq run <dataset>` — loads dataset, evaluates with Rich progress bar, prints results table, exits 1 on failures
  - `ragaliq list-evaluators` — Rich table of all registered evaluators with description and default threshold
  - `ragaliq validate <dataset>` — schema validation only (no API calls), exits 1 on bad format
  - `ragaliq version` — shows version (callback `--version`/`-V` also preserved)
- **`tests/unit/test_cli.py`**: Replaced 2 stale placeholder tests with 20 new tests covering all commands (success paths, error paths, option forwarding, argument validation)
- **`tests/unit/test_datasets.py`**: Auto-reformatted by ruff (no logic changes)

## Quality Gates

- ✅ `hatch run lint` — 0 errors in new files (49 pre-existing)
- ✅ `hatch run format` — clean
- ✅ `hatch run test` — 400 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)