### PR TITLE
[FEAT #15] Implement pytest plugin with rag_tester fixture, markers, and assert_rag_quality

### DIFF
--- a/examples/pytest_example/test_rag_quality.py
+++ b/examples/pytest_example/test_rag_quality.py
@@ -1,0 +1,85 @@
+"""
+Example: Using the RagaliQ pytest plugin for RAG quality testing.
+
+This file demonstrates how to write RAG quality tests using:
+  - The `rag_tester` fixture for direct evaluation
+  - The `ragaliq_judge` fixture with `assert_rag_quality()` helper
+  - `@pytest.mark.rag_test` and `@pytest.mark.rag_slow` markers
+
+Run with a real API key:
+    ANTHROPIC_API_KEY=sk-ant-... pytest examples/pytest_example/ -v
+
+Skip slow tests:
+    pytest examples/pytest_example/ -m "not rag_slow"
+"""
+
+import pytest
+
+from ragaliq.core.test_case import RAGTestCase
+from ragaliq.integrations.pytest_plugin import assert_rag_quality
+
+
+@pytest.mark.rag_test
+def test_faithful_answer(rag_tester):
+    """Faithful response — all facts present in the context."""
+    test_case = RAGTestCase(
+        id="ex-faithful-1",
+        name="Faithful capital answer",
+        query="What is the capital of France?",
+        context=["France is a country in Western Europe. Its capital city is Paris."],
+        response="The capital of France is Paris.",
+    )
+    result = rag_tester.evaluate(test_case)
+    assert result.passed, f"Quality check failed: {result.scores}"
+
+
+@pytest.mark.rag_test
+def test_relevant_answer(ragaliq_judge):
+    """Relevant response — uses assert_rag_quality helper."""
+    test_case = RAGTestCase(
+        id="ex-relevant-1",
+        name="Relevant ML answer",
+        query="What is machine learning?",
+        context=["Machine learning is a subset of AI that enables systems to learn from data."],
+        response="Machine learning is an AI technique that allows systems to improve from data.",
+    )
+    assert_rag_quality(test_case, judge=ragaliq_judge)
+
+
+@pytest.mark.rag_test
+@pytest.mark.rag_slow
+def test_multi_doc_context(rag_tester):
+    """Multi-document context — marked slow as it makes several judge calls."""
+    test_case = RAGTestCase(
+        id="ex-multi-1",
+        name="Multi-doc synthesis",
+        query="What are the benefits of async programming?",
+        context=[
+            "Async programming allows handling many tasks concurrently without blocking.",
+            "In Python, asyncio enables writing non-blocking I/O-bound code.",
+            "Async code improves throughput for network-bound applications.",
+        ],
+        response="Async programming improves concurrency and throughput for I/O-bound tasks.",
+    )
+    result = rag_tester.evaluate(test_case)
+    assert result.passed, f"Scores: {result.scores}"
+
+
+@pytest.mark.rag_test
+def test_with_custom_threshold(rag_tester):
+    """Custom threshold — requires stricter quality on this specific test."""
+    from ragaliq.core.runner import RagaliQ
+
+    strict_tester = RagaliQ(judge=rag_tester._judge, default_threshold=0.9)
+    test_case = RAGTestCase(
+        id="ex-strict-1",
+        name="Strict quality check",
+        query="Explain photosynthesis.",
+        context=[
+            "Photosynthesis is the process by which plants convert sunlight, "
+            "water, and CO2 into glucose and oxygen."
+        ],
+        response="Plants use sunlight, water, and CO2 to produce glucose and oxygen.",
+    )
+    result = strict_tester.evaluate(test_case)
+    assert result.passed, f"Strict quality check failed: {result.scores}"

--- a/src/ragaliq/cli/main.py
+++ b/src/ragaliq/cli/main.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Any
 
 import typer
 from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
@@ -68,7 +69,7 @@ def run(
     typer.echo(f"\nRagaliQ — {total} test case{'s' if total != 1 else ''} loaded\n")
 
     runner_obj = RagaliQ(
-        judge=judge,
+        judge=judge,  # type: ignore[arg-type]
         evaluators=evaluator if evaluator else None,
         default_threshold=threshold,
         fail_fast=fail_fast,
@@ -100,7 +101,7 @@ def run(
         typer.echo(f"\nSummary: {passed}/{total} passed")
 
 
-def _print_results_table(results: list, console: object) -> None:
+def _print_results_table(results: list[Any], console: object) -> None:
     """Render evaluation results as a Rich table.
 
     Args:

--- a/tests/unit/test_pytest_plugin.py
+++ b/tests/unit/test_pytest_plugin.py
@@ -1,5 +1,7 @@
 """Unit tests for the RagaliQ pytest plugin."""
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 
@@ -181,3 +183,219 @@ class TestLatencyInjection:
 
         # Test should pass
         assert result.ret == 0
+
+
+class TestMarkers:
+    """Test that new markers are registered."""
+
+    def test_rag_test_marker_registered(self, pytester: pytest.Pytester) -> None:
+        """@pytest.mark.rag_test should not trigger unknown-marker warnings."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.rag_test
+            def test_with_rag_test_marker():
+                assert True
+            """
+        )
+
+        result = pytester.runpytest("-p", "ragaliq", "-v")
+
+        assert result.ret == 0
+        output = result.stdout.str().lower()
+        assert "unknown mark" not in output
+        assert "unregistered mark" not in output
+
+    def test_rag_slow_marker_registered(self, pytester: pytest.Pytester) -> None:
+        """@pytest.mark.rag_slow should not trigger unknown-marker warnings."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.rag_slow
+            def test_with_rag_slow_marker():
+                assert True
+            """
+        )
+
+        result = pytester.runpytest("-p", "ragaliq", "-v")
+
+        assert result.ret == 0
+        output = result.stdout.str().lower()
+        assert "unknown mark" not in output
+        assert "unregistered mark" not in output
+
+    def test_rag_slow_marker_filterable(self, pytester: pytest.Pytester) -> None:
+        """Tests marked rag_slow can be deselected with -m 'not rag_slow'."""
+        pytester.makepyfile(
+            """
+            import pytest
+
+            @pytest.mark.rag_slow
+            def test_slow():
+                assert True
+
+            def test_fast():
+                assert True
+            """
+        )
+
+        result = pytester.runpytest("-p", "ragaliq", "-m", "not rag_slow", "-v")
+
+        assert result.ret == 0
+        output = result.stdout.str()
+        assert "test_fast" in output
+        assert "test_slow" not in output or "deselected" in output
+
+
+class TestRagTesterFixture:
+    """Test the rag_tester fixture."""
+
+    def test_rag_tester_fixture_available(self, pytester: pytest.Pytester) -> None:
+        """rag_tester fixture should provide a configured RagaliQ instance."""
+        pytester.makepyfile(
+            """
+            import os
+            os.environ["ANTHROPIC_API_KEY"] = "test-key-for-fixture-test"
+
+            def test_use_rag_tester(rag_tester):
+                from ragaliq.core.runner import RagaliQ
+                assert isinstance(rag_tester, RagaliQ)
+            """
+        )
+
+        result = pytester.runpytest("-p", "ragaliq", "-v")
+        assert result.ret == 0
+
+    def test_rag_tester_distinct_from_ragaliq_runner(self, pytester: pytest.Pytester) -> None:
+        """Both rag_tester and ragaliq_runner should be independently usable."""
+        pytester.makepyfile(
+            """
+            import os
+            os.environ["ANTHROPIC_API_KEY"] = "test-key"
+
+            def test_both_fixtures(rag_tester, ragaliq_runner):
+                from ragaliq.core.runner import RagaliQ
+                assert isinstance(rag_tester, RagaliQ)
+                assert isinstance(ragaliq_runner, RagaliQ)
+                # They are separate instances sharing the session judge
+                assert rag_tester is not ragaliq_runner
+            """
+        )
+
+        result = pytester.runpytest("-p", "ragaliq", "-v")
+        assert result.ret == 0
+
+
+class TestAssertRagQuality:
+    """Unit tests for the assert_rag_quality helper function."""
+
+    def _make_test_case(self) -> object:
+        """Build a minimal RAGTestCase."""
+        from ragaliq.core.test_case import RAGTestCase
+
+        return RAGTestCase(
+            id="test-1",
+            name="quality check",
+            query="What is 2+2?",
+            context=["Basic arithmetic: 2+2 equals 4."],
+            response="2+2 is 4.",
+        )
+
+    def _make_passing_result(self) -> MagicMock:
+        """Mock a RAGTestResult that passes."""
+        from ragaliq.core.test_case import EvalStatus
+
+        result = MagicMock()
+        result.passed = True
+        result.status = EvalStatus.PASSED
+        result.scores = {"faithfulness": 0.9, "relevance": 0.85}
+        return result
+
+    def _make_failing_result(self) -> MagicMock:
+        """Mock a RAGTestResult that fails."""
+        from ragaliq.core.test_case import EvalStatus
+
+        result = MagicMock()
+        result.passed = False
+        result.status = EvalStatus.FAILED
+        result.scores = {"faithfulness": 0.3, "relevance": 0.8}
+        return result
+
+    def test_returns_result_on_pass(self) -> None:
+        """assert_rag_quality returns the result when all metrics pass."""
+        from ragaliq.integrations.pytest_plugin import assert_rag_quality
+
+        test_case = self._make_test_case()
+
+        with patch(
+            "ragaliq.core.runner.RagaliQ.evaluate", return_value=self._make_passing_result()
+        ):
+            result = assert_rag_quality(test_case)
+
+        assert result is not None
+        assert result.passed is True
+
+    def test_raises_assertion_error_on_failure(self) -> None:
+        """assert_rag_quality raises AssertionError when any metric fails."""
+        from ragaliq.integrations.pytest_plugin import assert_rag_quality
+
+        test_case = self._make_test_case()
+
+        with (
+            patch("ragaliq.core.runner.RagaliQ.evaluate", return_value=self._make_failing_result()),
+            pytest.raises(AssertionError, match="RAG quality check failed"),
+        ):
+            assert_rag_quality(test_case)
+
+    def test_error_message_includes_test_name(self) -> None:
+        """AssertionError message includes the test case name."""
+        from ragaliq.integrations.pytest_plugin import assert_rag_quality
+
+        test_case = self._make_test_case()
+
+        with (
+            patch("ragaliq.core.runner.RagaliQ.evaluate", return_value=self._make_failing_result()),
+            pytest.raises(AssertionError, match="quality check"),
+        ):
+            assert_rag_quality(test_case)
+
+    def test_error_message_includes_failing_scores(self) -> None:
+        """AssertionError message includes the failing metric scores."""
+        from ragaliq.integrations.pytest_plugin import assert_rag_quality
+
+        test_case = self._make_test_case()
+
+        with (
+            patch("ragaliq.core.runner.RagaliQ.evaluate", return_value=self._make_failing_result()),
+            pytest.raises(AssertionError, match="faithfulness"),
+        ):
+            assert_rag_quality(test_case)
+
+    def test_accepts_pre_configured_judge(self) -> None:
+        """assert_rag_quality passes a provided judge through to RagaliQ."""
+        from ragaliq.integrations.pytest_plugin import assert_rag_quality
+
+        test_case = self._make_test_case()
+        mock_judge = MagicMock()
+
+        with patch("ragaliq.core.runner.RagaliQ") as mock_cls:
+            mock_cls.return_value.evaluate.return_value = self._make_passing_result()
+            assert_rag_quality(test_case, judge=mock_judge)
+
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["judge"] is mock_judge
+
+    def test_accepts_custom_threshold(self) -> None:
+        """assert_rag_quality forwards the threshold to RagaliQ."""
+        from ragaliq.integrations.pytest_plugin import assert_rag_quality
+
+        test_case = self._make_test_case()
+
+        with patch("ragaliq.core.runner.RagaliQ") as mock_cls:
+            mock_cls.return_value.evaluate.return_value = self._make_passing_result()
+            assert_rag_quality(test_case, threshold=0.9)
+
+        call_kwargs = mock_cls.call_args.kwargs
+        assert call_kwargs["default_threshold"] == 0.9


### PR DESCRIPTION
Closes #15

## Changes

- **`pytest_plugin.py`**: Three additions to the existing plugin skeleton:
  - `rag_test` and `rag_slow` markers registered in `pytest_configure` — no unknown-marker warnings, `rag_slow` filterable with `-m 'not rag_slow'`
  - `rag_tester` fixture — function-scoped, same session judge as `ragaliq_runner`, simpler name for test signatures
  - `assert_rag_quality(test_case, judge, evaluators, threshold)` — evaluates and raises `AssertionError` listing failing metrics and scores

- **`cli/main.py`**: Two mypy fixes — `# type: ignore[arg-type]` on the `str → Literal` judge param, and `list[Any]` type annotation

- **`examples/pytest_example/test_rag_quality.py`**: New file showing real usage of `rag_tester`, `ragaliq_judge`, `assert_rag_quality`, and both markers

- **`tests/unit/test_pytest_plugin.py`**: 11 new tests across three classes:
  - `TestMarkers` — marker registration + `-m not rag_slow` filtering
  - `TestRagTesterFixture` — availability + independence from `ragaliq_runner`
  - `TestAssertRagQuality` — pass/fail behavior, error message content, judge/threshold forwarding

## Quality Gates

- ✅ `hatch run lint` — 0 errors in new/modified files (pre-existing remain)
- ✅ `hatch run test` — 411 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)