### PR TITLE
[REFACTOR] Architectural audit: fix SyntaxError, extract claim pipeline, batch CLI, remove YAGNI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
     "rich>=14.3",
     "jinja2>=3.1",
     "pyyaml>=6.0",
-    "httpx>=0.28.1",
     "tenacity>=9.1",
 ]
 

--- a/src/ragaliq/core/runner.py
+++ b/src/ragaliq/core/runner.py
@@ -90,17 +90,17 @@ class RagaliQ:
 
         from ragaliq.judges.claude import ClaudeJudge
 
-        if self.judge_type == "claude":
-            self._judge = ClaudeJudge(
-                config=self._judge_config,
-                api_key=self._api_key,
-                max_concurrency=self.max_judge_concurrency,
-            )
-        elif self.judge_type == "openai":
-            # OpenAI judge not yet implemented
-            raise NotImplementedError("OpenAI judge not yet implemented")
-        else:
-            raise ValueError(f"Unknown judge type: {self.judge_type}")
+        match self.judge_type:
+            case "claude":
+                self._judge = ClaudeJudge(
+                    config=self._judge_config,
+                    api_key=self._api_key,
+                    max_concurrency=self.max_judge_concurrency,
+                )
+            case "openai":
+                raise NotImplementedError("OpenAI judge not yet implemented")
+            case _:
+                raise ValueError(f"Unknown judge type: {self.judge_type}")
 
     def _init_evaluators(self) -> None:
         """Initialize evaluators based on configuration."""

--- a/src/ragaliq/evaluators/__init__.py
+++ b/src/ragaliq/evaluators/__init__.py
@@ -8,9 +8,8 @@ from ragaliq.evaluators.context_recall import ContextRecallEvaluator
 from ragaliq.evaluators.faithfulness import FaithfulnessEvaluator
 from ragaliq.evaluators.hallucination import HallucinationEvaluator
 
-# Import registry functions and backward-compat dict
+# Import registry functions
 from ragaliq.evaluators.registry import (
-    EVALUATOR_REGISTRY,
     get_evaluator,
     list_evaluators,
     register_evaluator,
@@ -25,7 +24,6 @@ __all__ = [
     "FaithfulnessEvaluator",
     "HallucinationEvaluator",
     "RelevanceEvaluator",
-    "EVALUATOR_REGISTRY",
     "get_evaluator",
     "list_evaluators",
     "register_evaluator",

--- a/src/ragaliq/evaluators/_claims.py
+++ b/src/ragaliq/evaluators/_claims.py
@@ -1,0 +1,105 @@
+"""
+Shared claim verification pipeline for claim-based evaluators.
+
+This module extracts the common extract→verify→aggregate pattern used by
+FaithfulnessEvaluator and HallucinationEvaluator, eliminating duplication
+and providing a single place to maintain the claim verification flow.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ragaliq.judges.base import ClaimVerdict, LLMJudge
+
+
+@dataclass(frozen=True)
+class ClaimDetail:
+    """A single claim with its verification verdict and evidence."""
+
+    claim: str
+    verdict: str
+    evidence: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for raw_response metadata."""
+        return {
+            "claim": self.claim,
+            "verdict": self.verdict,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass(frozen=True)
+class ClaimVerificationResult:
+    """Result of verifying all claims extracted from a response.
+
+    Attributes:
+        claim_details: Per-claim verification results.
+        verdicts: Raw ClaimVerdict objects for further analysis.
+        total_tokens: Total tokens consumed across extraction and verification.
+        claims_empty: True if no claims were extracted (vacuous case).
+    """
+
+    claim_details: list[ClaimDetail] = field(default_factory=list)
+    verdicts: list[ClaimVerdict] = field(default_factory=list)
+    total_tokens: int = 0
+    claims_empty: bool = False
+
+
+async def verify_all_claims(
+    response: str,
+    context: list[str],
+    judge: LLMJudge,
+) -> ClaimVerificationResult:
+    """Extract claims from a response and verify each against the context.
+
+    Implements the shared pipeline:
+    1. Extract atomic claims via judge.extract_claims()
+    2. Verify each claim in parallel via judge.verify_claim()
+    3. Collect results with token tracking
+
+    Args:
+        response: The RAG system's generated response.
+        context: List of context documents to verify against.
+        judge: The LLM judge instance.
+
+    Returns:
+        ClaimVerificationResult with all claim details and verdicts.
+    """
+    # Step 1: Extract atomic claims
+    claims_result = await judge.extract_claims(response)
+    claims = claims_result.claims
+    total_tokens = claims_result.tokens_used
+
+    # Handle empty claims (vacuous case)
+    if not claims:
+        return ClaimVerificationResult(
+            claims_empty=True,
+            total_tokens=total_tokens,
+        )
+
+    # Step 2: Verify each claim in parallel
+    verification_tasks = [judge.verify_claim(claim, context) for claim in claims]
+    verdicts = await asyncio.gather(*verification_tasks)
+
+    # Step 3: Build detailed results
+    claim_details: list[ClaimDetail] = []
+    for i, verdict in enumerate(verdicts):
+        total_tokens += verdict.tokens_used
+        claim_details.append(
+            ClaimDetail(
+                claim=claims[i],
+                verdict=verdict.verdict,
+                evidence=verdict.evidence,
+            )
+        )
+
+    return ClaimVerificationResult(
+        claim_details=claim_details,
+        verdicts=list(verdicts),
+        total_tokens=total_tokens,
+    )

--- a/src/ragaliq/evaluators/faithfulness.py
+++ b/src/ragaliq/evaluators/faithfulness.py
@@ -13,9 +13,10 @@ Algorithm:
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING
 
 from ragaliq.core.evaluator import EvaluationResult, Evaluator
+from ragaliq.evaluators._claims import verify_all_claims
 from ragaliq.evaluators.registry import register_evaluator
 
 if TYPE_CHECKING:
@@ -83,13 +84,10 @@ class FaithfulnessEvaluator(Evaluator):
                 - reasoning: Human-readable explanation
                 - raw_response: Detailed claim-level metadata
         """
-        # Step 1: Extract atomic claims from the response
-        claims_result = await judge.extract_claims(test_case.response)
-        claims = claims_result.claims
-        total_tokens = claims_result.tokens_used
+        verification = await verify_all_claims(test_case.response, test_case.context, judge)
 
         # Handle empty claims edge case: vacuously faithful
-        if not claims:
+        if verification.claims_empty:
             return EvaluationResult(
                 evaluator_name=self.name,
                 score=1.0,
@@ -100,39 +98,14 @@ class FaithfulnessEvaluator(Evaluator):
                     "total_claims": 0,
                     "supported_claims": 0,
                 },
-                tokens_used=total_tokens,
+                tokens_used=verification.total_tokens,
             )
 
-        # Step 2: Verify each claim against the context (in parallel)
-        import asyncio
-
-        # Verify all claims concurrently (errors propagate)
-        verification_tasks = [judge.verify_claim(claim, test_case.context) for claim in claims]
-        verdicts = await asyncio.gather(*verification_tasks)
-
-        # Process results
-        claim_details: list[dict[str, Any]] = []
-        supported_count = 0
-
-        for i, verdict in enumerate(verdicts):
-            total_tokens += verdict.tokens_used
-
-            claim_details.append(
-                {
-                    "claim": claims[i],
-                    "verdict": verdict.verdict,
-                    "evidence": verdict.evidence,
-                }
-            )
-
-            if verdict.verdict == "SUPPORTED":
-                supported_count += 1
-
-        # Step 3: Calculate score as ratio
-        total_claims = len(claims)
+        # Count supported claims
+        supported_count = sum(1 for d in verification.claim_details if d.verdict == "SUPPORTED")
+        total_claims = len(verification.claim_details)
         score = supported_count / total_claims
 
-        # Step 4: Build reasoning
         reasoning = self._build_reasoning(supported_count, total_claims)
 
         return EvaluationResult(
@@ -141,11 +114,11 @@ class FaithfulnessEvaluator(Evaluator):
             passed=self.is_passing(score),
             reasoning=reasoning,
             raw_response={
-                "claims": claim_details,
+                "claims": [d.to_dict() for d in verification.claim_details],
                 "total_claims": total_claims,
                 "supported_claims": supported_count,
             },
-            tokens_used=total_tokens,
+            tokens_used=verification.total_tokens,
         )
 
     def _build_reasoning(self, supported: int, total: int) -> str:

--- a/src/ragaliq/evaluators/registry.py
+++ b/src/ragaliq/evaluators/registry.py
@@ -150,8 +150,3 @@ def list_evaluators() -> list[str]:
         # ['faithfulness', 'hallucination', 'relevance']
     """
     return sorted(_REGISTRY.keys())
-
-
-# Backward compatibility: expose the registry dict directly
-# (same object, so mutations are reflected)
-EVALUATOR_REGISTRY = _REGISTRY

--- a/src/ragaliq/judges/prompts/loader.py
+++ b/src/ragaliq/judges/prompts/loader.py
@@ -16,32 +16,6 @@ import yaml
 from pydantic import BaseModel, Field
 
 
-class OutputSchema(BaseModel):
-    """Schema definition for a single output field."""
-
-    type: str = Field(..., description="Data type of the field")
-    description: str = Field(default="", description="Field description")
-    min: float | None = Field(default=None, description="Minimum value for numeric types")
-    max: float | None = Field(default=None, description="Maximum value for numeric types")
-    enum: list[str] | None = Field(default=None, description="Allowed values for enum types")
-    items: dict[str, Any] | None = Field(default=None, description="Schema for array items")
-
-    model_config = {"extra": "forbid"}
-
-
-class OutputFormat(BaseModel):
-    """Output format specification for a prompt template."""
-
-    type: str = Field(..., description="Output type (e.g., 'json')")
-    schema_: dict[str, OutputSchema] = Field(
-        default_factory=dict,
-        alias="schema",
-        description="Schema definition for output fields",
-    )
-
-    model_config = {"extra": "forbid", "populate_by_name": True}
-
-
 class PromptExample(BaseModel):
     """A few-shot example for a prompt template."""
 
@@ -74,7 +48,7 @@ class PromptTemplate(BaseModel):
     description: str = Field(default="", description="Template description")
     system_prompt: str = Field(..., description="System prompt for the LLM")
     user_template: str = Field(..., description="User message template with placeholders")
-    output_format: OutputFormat | None = Field(default=None, description="Expected output format")
+    output_format: dict[str, Any] | None = Field(default=None, description="Expected output format")
     examples: list[PromptExample] = Field(default_factory=list, description="Few-shot examples")
 
     model_config = {"extra": "forbid"}

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,6 +1,6 @@
 """Unit tests for RagaliQ CLI entry point."""
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from typer.testing import CliRunner
 
@@ -179,7 +179,9 @@ class TestRunCommand:
             patch("ragaliq.datasets.DatasetLoader.load", return_value=mock_dataset),
             patch("ragaliq.RagaliQ") as mock_cls,
         ):
-            mock_cls.return_value.evaluate.return_value = self._mock_passing_result()
+            mock_cls.return_value.evaluate_batch_async = AsyncMock(
+                return_value=[self._mock_passing_result()]
+            )
             result = runner.invoke(app, ["run", "dataset.json"])
 
         assert result.exit_code == 0
@@ -193,7 +195,9 @@ class TestRunCommand:
             patch("ragaliq.datasets.DatasetLoader.load", return_value=mock_dataset),
             patch("ragaliq.RagaliQ") as mock_cls,
         ):
-            mock_cls.return_value.evaluate.return_value = self._mock_failing_result()
+            mock_cls.return_value.evaluate_batch_async = AsyncMock(
+                return_value=[self._mock_failing_result()]
+            )
             result = runner.invoke(app, ["run", "dataset.json"])
 
         assert result.exit_code == 1
@@ -233,7 +237,7 @@ class TestRunCommand:
             patch("ragaliq.datasets.DatasetLoader.load", return_value=mock_dataset),
             patch("ragaliq.RagaliQ") as mock_cls,
         ):
-            mock_cls.return_value.evaluate.return_value = mock_result
+            mock_cls.return_value.evaluate_batch_async = AsyncMock(return_value=[mock_result])
             runner.invoke(app, ["run", "dataset.json", "--evaluator", "relevance"])
 
         call_kwargs = mock_cls.call_args.kwargs
@@ -248,7 +252,9 @@ class TestRunCommand:
             patch("ragaliq.datasets.DatasetLoader.load", return_value=mock_dataset),
             patch("ragaliq.RagaliQ") as mock_cls,
         ):
-            mock_cls.return_value.evaluate.return_value = self._mock_passing_result()
+            mock_cls.return_value.evaluate_batch_async = AsyncMock(
+                return_value=[self._mock_passing_result()]
+            )
             runner.invoke(app, ["run", "dataset.json", "--threshold", "0.9"])
 
         call_kwargs = mock_cls.call_args.kwargs
@@ -263,7 +269,9 @@ class TestRunCommand:
             patch("ragaliq.datasets.DatasetLoader.load", return_value=mock_dataset),
             patch("ragaliq.RagaliQ") as mock_cls,
         ):
-            mock_cls.return_value.evaluate.return_value = self._mock_passing_result()
+            mock_cls.return_value.evaluate_batch_async = AsyncMock(
+                return_value=[self._mock_passing_result()]
+            )
             result = runner.invoke(app, ["run", "dataset.json"])
 
         assert "1/1 passed" in result.output

--- a/tests/unit/test_context_precision_evaluator.py
+++ b/tests/unit/test_context_precision_evaluator.py
@@ -749,11 +749,10 @@ class TestContextPrecisionRegistration:
     """Tests that ContextPrecisionEvaluator is properly registered."""
 
     def test_registered_in_registry(self) -> None:
-        """Should be registered as 'context_precision' in EVALUATOR_REGISTRY."""
-        from ragaliq.evaluators import EVALUATOR_REGISTRY
+        """Should be registered as 'context_precision' in the evaluator registry."""
+        from ragaliq.evaluators import get_evaluator
 
-        assert "context_precision" in EVALUATOR_REGISTRY
-        assert EVALUATOR_REGISTRY["context_precision"] is ContextPrecisionEvaluator
+        assert get_evaluator("context_precision") is ContextPrecisionEvaluator
 
     def test_retrievable_via_get_evaluator(self) -> None:
         """Should be retrievable via get_evaluator()."""

--- a/tests/unit/test_context_recall_evaluator.py
+++ b/tests/unit/test_context_recall_evaluator.py
@@ -729,11 +729,10 @@ class TestContextRecallRegistration:
     """Tests that ContextRecallEvaluator is properly registered."""
 
     def test_registered_in_registry(self) -> None:
-        """Should be registered as 'context_recall' in EVALUATOR_REGISTRY."""
-        from ragaliq.evaluators import EVALUATOR_REGISTRY
+        """Should be registered as 'context_recall' in the evaluator registry."""
+        from ragaliq.evaluators import get_evaluator
 
-        assert "context_recall" in EVALUATOR_REGISTRY
-        assert EVALUATOR_REGISTRY["context_recall"] is ContextRecallEvaluator
+        assert get_evaluator("context_recall") is ContextRecallEvaluator
 
     def test_retrievable_via_get_evaluator(self) -> None:
         """Should be retrievable via get_evaluator()."""

--- a/tests/unit/test_evaluator_registry.py
+++ b/tests/unit/test_evaluator_registry.py
@@ -8,7 +8,6 @@ import pytest
 
 from ragaliq.core.evaluator import EvaluationResult, Evaluator
 from ragaliq.evaluators.registry import (
-    EVALUATOR_REGISTRY,
     get_evaluator,
     list_evaluators,
     register_evaluator,
@@ -54,8 +53,7 @@ class TestRegisterEvaluatorDecorator:
                     reasoning="Test",
                 )
 
-        assert "test_metric" in EVALUATOR_REGISTRY
-        assert EVALUATOR_REGISTRY["test_metric"] is TestEvaluator
+        assert get_evaluator("test_metric") is TestEvaluator
 
     def test_returns_class_unchanged(self, clean_registry):
         """Decorator should return the class unchanged (type-preserving)."""
@@ -159,8 +157,7 @@ class TestRegisterEvaluatorClass:
 
         register_evaluator_class("test_metric", TestEvaluator)
 
-        assert "test_metric" in EVALUATOR_REGISTRY
-        assert EVALUATOR_REGISTRY["test_metric"] is TestEvaluator
+        assert get_evaluator("test_metric") is TestEvaluator
 
     def test_rejects_non_evaluator_class(self, clean_registry):
         """Should reject classes that don't subclass Evaluator."""
@@ -295,22 +292,19 @@ class TestBuiltInRegistration:
         """FaithfulnessEvaluator should be registered as 'faithfulness'."""
         from ragaliq.evaluators import FaithfulnessEvaluator
 
-        assert "faithfulness" in EVALUATOR_REGISTRY
-        assert EVALUATOR_REGISTRY["faithfulness"] is FaithfulnessEvaluator
+        assert get_evaluator("faithfulness") is FaithfulnessEvaluator
 
     def test_relevance_registered(self):
         """RelevanceEvaluator should be registered as 'relevance'."""
         from ragaliq.evaluators import RelevanceEvaluator
 
-        assert "relevance" in EVALUATOR_REGISTRY
-        assert EVALUATOR_REGISTRY["relevance"] is RelevanceEvaluator
+        assert get_evaluator("relevance") is RelevanceEvaluator
 
     def test_hallucination_registered(self):
         """HallucinationEvaluator should be registered as 'hallucination'."""
         from ragaliq.evaluators import HallucinationEvaluator
 
-        assert "hallucination" in EVALUATOR_REGISTRY
-        assert EVALUATOR_REGISTRY["hallucination"] is HallucinationEvaluator
+        assert get_evaluator("hallucination") is HallucinationEvaluator
 
     def test_all_built_ins_retrievable(self):
         """All built-in evaluators should be retrievable via get_evaluator()."""
@@ -323,30 +317,6 @@ class TestBuiltInRegistration:
         assert get_evaluator("faithfulness") is FaithfulnessEvaluator
         assert get_evaluator("relevance") is RelevanceEvaluator
         assert get_evaluator("hallucination") is HallucinationEvaluator
-
-
-class TestBackwardCompatibility:
-    """Tests for backward compatibility with the EVALUATOR_REGISTRY dict."""
-
-    def test_evaluator_registry_importable(self):
-        """EVALUATOR_REGISTRY should be importable from evaluators package."""
-        from ragaliq.evaluators import EVALUATOR_REGISTRY as reg
-
-        assert isinstance(reg, dict)
-
-    def test_evaluator_registry_is_same_dict(self):
-        """EVALUATOR_REGISTRY should be the same dict object as _REGISTRY."""
-        import ragaliq.evaluators.registry as reg_module
-        from ragaliq.evaluators import EVALUATOR_REGISTRY as public_reg
-
-        # Should be the exact same object (mutations reflected)
-        assert public_reg is reg_module._REGISTRY
-
-    def test_can_access_built_ins_via_dict(self):
-        """Should be able to access built-in evaluators via EVALUATOR_REGISTRY dict."""
-        from ragaliq.evaluators import EVALUATOR_REGISTRY, FaithfulnessEvaluator
-
-        assert EVALUATOR_REGISTRY["faithfulness"] is FaithfulnessEvaluator
 
 
 class TestCustomEvaluatorRegistration:

--- a/tests/unit/test_prompts.py
+++ b/tests/unit/test_prompts.py
@@ -121,7 +121,7 @@ class TestFaithfulnessTemplate:
     def test_output_format(self, template: PromptTemplate) -> None:
         """Template should specify output format."""
         assert template.output_format is not None
-        assert template.output_format.type == "json"
+        assert template.output_format["type"] == "json"
 
 
 class TestRelevanceTemplate:
@@ -174,7 +174,7 @@ class TestExtractClaimsTemplate:
     def test_output_format_claims_array(self, template: PromptTemplate) -> None:
         """Output format should specify claims as array."""
         assert template.output_format is not None
-        assert "claims" in template.output_format.schema_
+        assert "claims" in template.output_format["schema"]
 
     def test_has_examples(self, template: PromptTemplate) -> None:
         """Template should have few-shot examples."""
@@ -205,7 +205,7 @@ class TestVerifyClaimTemplate:
     def test_output_format_verdict(self, template: PromptTemplate) -> None:
         """Output format should specify verdict enum."""
         assert template.output_format is not None
-        assert "verdict" in template.output_format.schema_
+        assert "verdict" in template.output_format["schema"]
 
     def test_has_examples(self, template: PromptTemplate) -> None:
         """Template should have few-shot examples."""


### PR DESCRIPTION
## Summary

- **Fix SyntaxError** in `pytest_plugin.py` — `except ImportError, ModuleNotFoundError:` → `except (ImportError, ModuleNotFoundError):`
- **Extract `evaluators/_claims.py`** — shared claim verification pipeline (`verify_all_claims`) eliminates ~80% code duplication between `FaithfulnessEvaluator` and `HallucinationEvaluator`
- **CLI batch evaluation** — replaces serial `evaluate()` loop with `asyncio.run(evaluate_batch_async())`, creating a single event loop instead of N
- **`match/case` dispatch** — structural pattern matching in `runner._init_judge()` and `pytest_plugin.ragaliq_judge()`
- **Remove YAGNI** — dead `httpx` dependency, unused `OutputSchema`/`OutputFormat` Pydantic classes, `EVALUATOR_REGISTRY` backward-compat alias
- **Type annotation fixes** — `assert_rag_quality`, `judge_factory`, `_print_results_table`

## Changes

- `e2f08d3` [REFACTOR] Architectural audit: fix SyntaxError, extract claim pipeline, batch CLI, remove YAGNI

## Checks

- [x] `hatch run lint` — 49 pre-existing errors, none introduced
- [x] `hatch run test` — 408 passed, 1 skipped
- [x] No secrets, debug code, or TODOs introduced
- [x] Tests updated for all changed interfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)