### PR TITLE
[REFACTOR] Fix all 49 ruff lint warnings — lint now exits 0

### DIFF
--- a/src/ragaliq/core/test_case.py
+++ b/src/ragaliq/core/test_case.py
@@ -1,12 +1,12 @@
 """Test case models for RagaliQ."""
 
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel, Field
 
 
-class EvalStatus(str, Enum):
+class EvalStatus(StrEnum):
     """Status of an evaluation execution."""
 
     PASSED = "passed"

--- a/src/ragaliq/integrations/pytest_plugin.py
+++ b/src/ragaliq/integrations/pytest_plugin.py
@@ -327,7 +327,7 @@ def pytest_runtest_makereport(item: Any, call: Any) -> None:
         )
 
 
-def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: Any) -> None:
+def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: Any) -> None:  # noqa: ARG001
     """
     Add RagaliQ summary to pytest terminal output.
 

--- a/tests/unit/test_evaluator_registry.py
+++ b/tests/unit/test_evaluator_registry.py
@@ -37,7 +37,7 @@ def clean_registry():
 class TestRegisterEvaluatorDecorator:
     """Tests for the @register_evaluator decorator."""
 
-    def test_registers_evaluator_class(self, clean_registry):
+    def test_registers_evaluator_class(self, clean_registry) -> None:  # noqa: ARG002
         """Decorator should register the class in the global registry."""
 
         @register_evaluator("test_metric")
@@ -45,7 +45,7 @@ class TestRegisterEvaluatorDecorator:
             name = "test_metric"
             description = "Test evaluator"
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=1.0,
@@ -55,7 +55,7 @@ class TestRegisterEvaluatorDecorator:
 
         assert get_evaluator("test_metric") is TestEvaluator
 
-    def test_returns_class_unchanged(self, clean_registry):
+    def test_returns_class_unchanged(self, clean_registry) -> None:  # noqa: ARG002
         """Decorator should return the class unchanged (type-preserving)."""
 
         @register_evaluator("test_metric")
@@ -63,7 +63,7 @@ class TestRegisterEvaluatorDecorator:
             name = "test_metric"
             description = "Test evaluator"
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=1.0,
@@ -75,7 +75,7 @@ class TestRegisterEvaluatorDecorator:
         assert TestEvaluator.name == "test_metric"
         assert TestEvaluator.description == "Test evaluator"
 
-    def test_rejects_non_evaluator_class(self, clean_registry):
+    def test_rejects_non_evaluator_class(self, clean_registry) -> None:  # noqa: ARG002
         """Decorator should reject classes that don't subclass Evaluator."""
         with pytest.raises(ValueError, match="must be a subclass of Evaluator"):
 
@@ -83,7 +83,7 @@ class TestRegisterEvaluatorDecorator:
             class NotAnEvaluator:
                 pass
 
-    def test_rejects_empty_name(self, clean_registry):
+    def test_rejects_empty_name(self, clean_registry) -> None:  # noqa: ARG002
         """Decorator should reject empty evaluator names."""
         with pytest.raises(ValueError, match="name cannot be empty"):
 
@@ -93,7 +93,7 @@ class TestRegisterEvaluatorDecorator:
                 description = "Test"
 
                 async def evaluate(
-                    self, test_case: RAGTestCase, judge: LLMJudge
+                    self, _test_case: RAGTestCase, _judge: LLMJudge
                 ) -> EvaluationResult:
                     return EvaluationResult(
                         evaluator_name=self.name,
@@ -102,7 +102,7 @@ class TestRegisterEvaluatorDecorator:
                         reasoning="Test",
                     )
 
-    def test_rejects_duplicate_name(self, clean_registry):
+    def test_rejects_duplicate_name(self, clean_registry) -> None:  # noqa: ARG002
         """Decorator should reject duplicate evaluator names."""
 
         @register_evaluator("duplicate")
@@ -110,7 +110,7 @@ class TestRegisterEvaluatorDecorator:
             name = "duplicate"
             description = "First"
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=1.0,
@@ -127,7 +127,7 @@ class TestRegisterEvaluatorDecorator:
                 description = "Second"
 
                 async def evaluate(
-                    self, test_case: RAGTestCase, judge: LLMJudge
+                    self, _test_case: RAGTestCase, _judge: LLMJudge
                 ) -> EvaluationResult:
                     return EvaluationResult(
                         evaluator_name=self.name,
@@ -140,14 +140,14 @@ class TestRegisterEvaluatorDecorator:
 class TestRegisterEvaluatorClass:
     """Tests for the programmatic register_evaluator_class() function."""
 
-    def test_registers_evaluator_class(self, clean_registry):
+    def test_registers_evaluator_class(self, clean_registry) -> None:  # noqa: ARG002
         """Should register the class programmatically."""
 
         class TestEvaluator(Evaluator):
             name = "test_metric"
             description = "Test evaluator"
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=1.0,
@@ -159,7 +159,7 @@ class TestRegisterEvaluatorClass:
 
         assert get_evaluator("test_metric") is TestEvaluator
 
-    def test_rejects_non_evaluator_class(self, clean_registry):
+    def test_rejects_non_evaluator_class(self, clean_registry) -> None:  # noqa: ARG002
         """Should reject classes that don't subclass Evaluator."""
 
         class NotAnEvaluator:
@@ -168,14 +168,14 @@ class TestRegisterEvaluatorClass:
         with pytest.raises(ValueError, match="must be a subclass of Evaluator"):
             register_evaluator_class("not_an_evaluator", NotAnEvaluator)  # type: ignore[arg-type]
 
-    def test_rejects_empty_name(self, clean_registry):
+    def test_rejects_empty_name(self, clean_registry) -> None:  # noqa: ARG002
         """Should reject empty evaluator names."""
 
         class TestEvaluator(Evaluator):
             name = "test"
             description = "Test"
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=1.0,
@@ -189,14 +189,14 @@ class TestRegisterEvaluatorClass:
         with pytest.raises(ValueError, match="name cannot be empty"):
             register_evaluator_class("   ", TestEvaluator)
 
-    def test_rejects_duplicate_name(self, clean_registry):
+    def test_rejects_duplicate_name(self, clean_registry) -> None:  # noqa: ARG002
         """Should reject duplicate evaluator names."""
 
         class FirstEvaluator(Evaluator):
             name = "duplicate"
             description = "First"
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=1.0,
@@ -208,7 +208,7 @@ class TestRegisterEvaluatorClass:
             name = "duplicate"
             description = "Second"
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=1.0,
@@ -265,7 +265,7 @@ class TestListEvaluators:
         assert "relevance" in evaluators
         assert "hallucination" in evaluators
 
-    def test_includes_custom_evaluators(self, clean_registry):
+    def test_includes_custom_evaluators(self, clean_registry) -> None:  # noqa: ARG002
         """Should include custom evaluators after registration."""
 
         @register_evaluator("custom_metric")
@@ -273,7 +273,7 @@ class TestListEvaluators:
             name = "custom_metric"
             description = "Custom"
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=1.0,
@@ -322,7 +322,7 @@ class TestBuiltInRegistration:
 class TestCustomEvaluatorRegistration:
     """Tests for user-defined custom evaluator registration."""
 
-    def test_custom_evaluator_via_decorator(self, clean_registry):
+    def test_custom_evaluator_via_decorator(self, clean_registry) -> None:  # noqa: ARG002
         """Users should be able to register custom evaluators using the decorator."""
 
         @register_evaluator("user_custom")
@@ -330,7 +330,7 @@ class TestCustomEvaluatorRegistration:
             name = "user_custom"
             description = "User's custom evaluator"
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=0.95,
@@ -350,14 +350,14 @@ class TestCustomEvaluatorRegistration:
         assert evaluator.name == "user_custom"
         assert evaluator.threshold == 0.8
 
-    def test_custom_evaluator_via_programmatic_api(self, clean_registry):
+    def test_custom_evaluator_via_programmatic_api(self, clean_registry) -> None:  # noqa: ARG002
         """Users should be able to register custom evaluators programmatically."""
 
         class UserCustomEvaluator(Evaluator):
             name = "programmatic_custom"
             description = "Programmatically registered"
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=0.85,
@@ -374,7 +374,7 @@ class TestCustomEvaluatorRegistration:
         # Should be in list
         assert "programmatic_custom" in list_evaluators()
 
-    def test_custom_evaluator_with_custom_threshold(self, clean_registry):
+    def test_custom_evaluator_with_custom_threshold(self, clean_registry) -> None:  # noqa: ARG002
         """Custom evaluators should support custom default thresholds."""
 
         @register_evaluator("strict_custom")
@@ -383,7 +383,7 @@ class TestCustomEvaluatorRegistration:
             description = "Strict evaluator"
             threshold = 0.95  # Custom default threshold
 
-            async def evaluate(self, test_case: RAGTestCase, judge: LLMJudge) -> EvaluationResult:
+            async def evaluate(self, _test_case: RAGTestCase, _judge: LLMJudge) -> EvaluationResult:
                 return EvaluationResult(
                     evaluator_name=self.name,
                     score=0.9,

--- a/tests/unit/test_judges.py
+++ b/tests/unit/test_judges.py
@@ -251,7 +251,7 @@ class TestLLMJudge:
         class MockJudge(LLMJudge):
             async def evaluate_faithfulness(
                 self,
-                response: str,
+                response: str,  # noqa: ARG002
                 context: list[str],  # noqa: ARG002
             ) -> JudgeResult:
                 return JudgeResult(
@@ -262,7 +262,7 @@ class TestLLMJudge:
 
             async def evaluate_relevance(
                 self,
-                query: str,
+                query: str,  # noqa: ARG002
                 response: str,  # noqa: ARG002
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
@@ -288,14 +288,14 @@ class TestLLMJudge:
         class MockJudge(LLMJudge):
             async def evaluate_faithfulness(
                 self,
-                response: str,
+                response: str,  # noqa: ARG002
                 context: list[str],  # noqa: ARG002
             ) -> JudgeResult:
                 return JudgeResult(score=1.0)
 
             async def evaluate_relevance(
                 self,
-                query: str,
+                query: str,  # noqa: ARG002
                 response: str,  # noqa: ARG002
             ) -> JudgeResult:
                 return JudgeResult(

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -285,7 +285,7 @@ class TestBoundedConcurrency:
         concurrent_calls = 0
         max_concurrent = 0
 
-        async def mock_send(*args, **kwargs):
+        async def mock_send(*_args, **_kwargs):
             nonlocal concurrent_calls, max_concurrent
             concurrent_calls += 1
             max_concurrent = max(max_concurrent, concurrent_calls)

--- a/tests/unit/test_trace.py
+++ b/tests/unit/test_trace.py
@@ -1,8 +1,10 @@
 """Unit tests for JudgeTrace and TraceCollector."""
 
+import contextlib
 from datetime import UTC, datetime
 
 import pytest
+from pydantic import ValidationError
 
 from ragaliq.judges.trace import JudgeTrace, TraceCollector
 
@@ -59,7 +61,7 @@ class TestJudgeTrace:
             success=True,
         )
 
-        with pytest.raises(Exception):  # Pydantic raises validation error on frozen model
+        with pytest.raises(ValidationError):  # Pydantic raises validation error on frozen model
             trace.success = False  # type: ignore[misc]
 
 
@@ -118,10 +120,8 @@ class TestTraceModelAccuracy:
         judge = BaseJudge(transport=mock_transport, config=config, trace_collector=collector)
 
         # Make a call that fails
-        try:
+        with contextlib.suppress(RuntimeError):
             await judge._call_llm("system", "user", operation="test_op")
-        except RuntimeError:
-            pass
 
         # Trace should record config model (no response to get actual model from)
         assert len(collector.traces) == 1


### PR DESCRIPTION
## Summary

Resolves all 49 pre-existing ruff warnings so `hatch run lint` exits 0 cleanly.

| Rule | Count | Fix |
|------|-------|-----|
| UP042 | 1 | `EvalStatus(str, Enum)` → `EvalStatus(StrEnum)` in `core/test_case.py` |
| ARG001 | 3 | `# noqa` on pytest hook `exitstatus` (name is required); `*_args/**_kwargs` in mock |
| ARG002 | 43 | `_test_case`/`_judge` in evaluate stubs; `# noqa` on fixture/interface params |
| B017 | 1 | `pytest.raises(ValidationError)` instead of bare `Exception` |
| SIM105 | 1 | `contextlib.suppress(RuntimeError)` replaces try/except/pass |

## Checks

- [x] `hatch run lint` — **0 errors, exits 0**
- [x] `hatch run test` — 408 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)