### PR TITLE
[FEAT #17] Task 16: JSON & HTML Reports

### DIFF
--- a/src/ragaliq/datasets/generator.py
+++ b/src/ragaliq/datasets/generator.py
@@ -85,7 +85,9 @@ class TestCaseGenerator:
                 response=answer_result.answer,
                 tags=["generated"],
             )
-            for i, (question, answer_result) in enumerate(zip(questions, answer_results, strict=True), start=1)
+            for i, (question, answer_result) in enumerate(
+                zip(questions, answer_results, strict=True), start=1
+            )
         ]
 
     def generate_from_documents_sync(

--- a/src/ragaliq/reports/__init__.py
+++ b/src/ragaliq/reports/__init__.py
@@ -1,5 +1,7 @@
 """Reports package for RagaliQ."""
 
 from ragaliq.reports.console import ConsoleReporter
+from ragaliq.reports.html import HTMLReporter
+from ragaliq.reports.json_export import JSONReporter
 
-__all__ = ["ConsoleReporter"]
+__all__ = ["ConsoleReporter", "HTMLReporter", "JSONReporter"]

--- a/src/ragaliq/reports/console.py
+++ b/src/ragaliq/reports/console.py
@@ -112,9 +112,7 @@ class ConsoleReporter:
         from ragaliq.core.test_case import EvalStatus
 
         targets = [
-            r
-            for r in results
-            if self._verbose or r.status in {EvalStatus.FAILED, EvalStatus.ERROR}
+            r for r in results if self._verbose or r.status in {EvalStatus.FAILED, EvalStatus.ERROR}
         ]
         if not targets:
             return
@@ -123,9 +121,7 @@ class ConsoleReporter:
 
         for result in targets:
             self._console.print(f"\n[bold]{result.test_case.name}[/bold]")
-            details: dict[str, Any] = (
-                result.details if isinstance(result.details, dict) else {}
-            )
+            details: dict[str, Any] = result.details if isinstance(result.details, dict) else {}
             for evaluator_name, detail in details.items():
                 if not isinstance(detail, dict):
                     continue
@@ -137,9 +133,7 @@ class ConsoleReporter:
                         f"  [yellow]{evaluator_name}[/yellow] [red]ERROR[/red]: {error}"
                     )
                 elif score is not None and score < self._threshold and reasoning:
-                    self._console.print(
-                        f"  [yellow]{evaluator_name}[/yellow]: {reasoning}"
-                    )
+                    self._console.print(f"  [yellow]{evaluator_name}[/yellow]: {reasoning}")
 
     def _print_summary(self, results: list[RAGTestResult]) -> None:
         """Print per-evaluator statistics and overall pass/fail count."""

--- a/src/ragaliq/reports/html.py
+++ b/src/ragaliq/reports/html.py
@@ -1,0 +1,147 @@
+"""HTML report exporter for RagaliQ evaluation results."""
+
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ragaliq.core.test_case import RAGTestResult
+
+
+class HTMLReporter:
+    """
+    HTML report exporter for evaluation results.
+
+    Renders a self-contained HTML file using a Jinja2 template with
+    embedded CSS — no external dependencies, no JavaScript.
+
+    Features:
+    - Summary cards (total, passed, failed, errored, pass rate, tokens)
+    - Per-evaluator statistics table
+    - Results table with colour-coded scores
+    - Expandable failure details via HTML5 <details>/<summary>
+
+    Example:
+        >>> reporter = HTMLReporter(threshold=0.7)
+        >>> html = reporter.export(results)
+        >>> Path("report.html").write_text(html, encoding="utf-8")
+    """
+
+    _TEMPLATE_DIR = Path(__file__).parent / "templates"
+    _TEMPLATE_NAME = "report.html.j2"
+
+    def __init__(self, threshold: float = 0.7) -> None:
+        """
+        Initialize HTMLReporter.
+
+        Args:
+            threshold: Score threshold for pass/fail coloring (0.0–1.0).
+        """
+        self._threshold = threshold
+
+    def export(self, results: list[RAGTestResult]) -> str:
+        """
+        Render evaluation results to a self-contained HTML string.
+
+        Args:
+            results: List of evaluation results to render.
+
+        Returns:
+            Complete HTML document as a string.
+        """
+        from jinja2 import Environment, FileSystemLoader
+
+        env = Environment(
+            loader=FileSystemLoader(str(self._TEMPLATE_DIR)),
+            autoescape=True,
+        )
+        template = env.get_template(self._TEMPLATE_NAME)
+        context = self._build_context(results)
+        return template.render(**context)
+
+    def _build_context(self, results: list[RAGTestResult]) -> dict[str, Any]:
+        """Prepare the template context from evaluation results."""
+        from ragaliq.core.test_case import EvalStatus
+
+        evaluator_names = sorted(results[0].scores.keys()) if results else []
+
+        # Per-evaluator aggregate stats
+        ev_rows = []
+        for name in evaluator_names:
+            scores = [r.scores[name] for r in results if name in r.scores]
+            ev_passed = sum(1 for s in scores if s >= self._threshold)
+            avg = sum(scores) / len(scores) if scores else 0.0
+            ev_rows.append(
+                {
+                    "name": name,
+                    "passed": ev_passed,
+                    "failed": len(scores) - ev_passed,
+                    "avg_score": avg,
+                }
+            )
+
+        # Per-result data with pre-processed scores and failure details
+        processed: list[dict[str, Any]] = []
+        for result in results:
+            # Score cells ordered by evaluator_names
+            score_cells = []
+            for name in evaluator_names:
+                value = result.scores.get(name)
+                score_cells.append(
+                    {
+                        "value": value,
+                        "passes": value is not None and value >= self._threshold,
+                    }
+                )
+
+            # Failure details (reasoning / errors for failing evaluators)
+            failing_details: list[dict[str, Any]] = []
+            if not result.passed and isinstance(result.details, dict):
+                for ev_name, detail in result.details.items():
+                    if not isinstance(detail, dict):
+                        continue
+                    score = result.scores.get(ev_name)
+                    error: str = detail.get("error", "")
+                    reasoning: str = detail.get("reasoning", "")
+                    if error:
+                        failing_details.append(
+                            {"evaluator": ev_name, "text": error, "is_error": True}
+                        )
+                    elif score is not None and score < self._threshold and reasoning:
+                        failing_details.append(
+                            {"evaluator": ev_name, "text": reasoning, "is_error": False}
+                        )
+
+            processed.append(
+                {
+                    "name": result.test_case.name,
+                    "status": str(result.status),
+                    "passed": result.passed,
+                    "scores": score_cells,
+                    "execution_time_ms": result.execution_time_ms,
+                    "failing_details": failing_details,
+                }
+            )
+
+        total = len(results)
+        passed = sum(1 for r in results if r.passed)
+        errored = sum(1 for r in results if r.status == EvalStatus.ERROR)
+        total_tokens = sum(r.judge_tokens_used for r in results)
+        generated_at = datetime.datetime.now(datetime.UTC).strftime("%Y-%m-%d %H:%M UTC")
+
+        return {
+            "generated_at": generated_at,
+            "threshold": self._threshold,
+            "summary": {
+                "total": total,
+                "passed": passed,
+                "failed": total - passed,
+                "errored": errored,
+                "pass_rate": passed / total if total else 0.0,
+                "total_tokens": total_tokens,
+            },
+            "evaluators": ev_rows,
+            "results": processed,
+        }

--- a/src/ragaliq/reports/json_export.py
+++ b/src/ragaliq/reports/json_export.py
@@ -1,0 +1,128 @@
+"""JSON report exporter for RagaliQ evaluation results."""
+
+from __future__ import annotations
+
+import datetime
+import json
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from ragaliq.core.test_case import RAGTestResult
+
+
+class JSONReporter:
+    """
+    JSON report exporter for evaluation results.
+
+    Produces a structured JSON document with a summary section and
+    full per-result data, suitable for CI artefact storage or
+    downstream processing.
+
+    Example:
+        >>> reporter = JSONReporter(threshold=0.7)
+        >>> json_str = reporter.export(results)
+        >>> Path("report.json").write_text(json_str)
+
+    Output structure::
+
+        {
+          "generated_at": "2026-01-01T00:00:00+00:00",
+          "threshold": 0.7,
+          "summary": {
+            "total": 3,
+            "passed": 2,
+            "failed": 1,
+            "errored": 0,
+            "pass_rate": 0.6667,
+            "total_tokens": 1500,
+            "total_execution_ms": 3400,
+            "evaluators": {
+              "faithfulness": {"passed": 2, "failed": 1, "avg_score": 0.733}
+            }
+          },
+          "results": [...]
+        }
+    """
+
+    def __init__(self, threshold: float = 0.7) -> None:
+        """
+        Initialize JSONReporter.
+
+        Args:
+            threshold: Score threshold for pass/fail classification (0.0–1.0).
+        """
+        self._threshold = threshold
+
+    def export(self, results: list[RAGTestResult]) -> str:
+        """
+        Serialize evaluation results to a JSON string.
+
+        Args:
+            results: List of evaluation results to export.
+
+        Returns:
+            Pretty-printed JSON string (indent=2, UTF-8 safe).
+        """
+        from ragaliq.core.test_case import EvalStatus
+
+        evaluator_names = sorted(results[0].scores.keys()) if results else []
+
+        # Per-evaluator aggregate statistics
+        ev_stats: dict[str, dict[str, Any]] = {}
+        for name in evaluator_names:
+            scores = [r.scores[name] for r in results if name in r.scores]
+            ev_passed = sum(1 for s in scores if s >= self._threshold)
+            avg = sum(scores) / len(scores) if scores else 0.0
+            ev_stats[name] = {
+                "passed": ev_passed,
+                "failed": len(scores) - ev_passed,
+                "avg_score": round(avg, 4),
+            }
+
+        total = len(results)
+        passed = sum(1 for r in results if r.passed)
+        errored = sum(1 for r in results if r.status == EvalStatus.ERROR)
+        total_tokens = sum(r.judge_tokens_used for r in results)
+        total_ms = sum(r.execution_time_ms for r in results)
+
+        doc = {
+            "generated_at": datetime.datetime.now(datetime.UTC).isoformat(),
+            "threshold": self._threshold,
+            "summary": {
+                "total": total,
+                "passed": passed,
+                "failed": total - passed,
+                "errored": errored,
+                "pass_rate": round(passed / total, 4) if total else 0.0,
+                "total_tokens": total_tokens,
+                "total_execution_ms": total_ms,
+                "evaluators": ev_stats,
+            },
+            "results": [self._serialize_result(r) for r in results],
+        }
+
+        return json.dumps(doc, indent=2, ensure_ascii=False)
+
+    def _serialize_result(self, result: RAGTestResult) -> dict[str, Any]:
+        """Serialize a single RAGTestResult to a plain dict."""
+        tc = result.test_case
+        return {
+            "id": tc.id,
+            "name": tc.name,
+            "status": str(result.status),
+            "passed": result.passed,
+            "scores": result.scores,
+            "details": result.details,
+            "execution_time_ms": result.execution_time_ms,
+            "judge_tokens_used": result.judge_tokens_used,
+            "test_case": {
+                "id": tc.id,
+                "name": tc.name,
+                "query": tc.query,
+                "context": tc.context,
+                "response": tc.response,
+                "expected_answer": tc.expected_answer,
+                "expected_facts": tc.expected_facts,
+                "tags": tc.tags,
+            },
+        }

--- a/src/ragaliq/reports/templates/report.html.j2
+++ b/src/ragaliq/reports/templates/report.html.j2
@@ -1,0 +1,300 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RagaliQ Evaluation Report</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      background: #f0f2f5;
+      color: #1a1a1a;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    header {
+      background: #0f172a;
+      color: #f1f5f9;
+      padding: 1.25rem 2rem;
+      display: flex;
+      align-items: baseline;
+      gap: 1.5rem;
+    }
+    header h1 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; }
+    header .meta { font-size: 0.8rem; color: #94a3b8; }
+
+    .container { max-width: 1200px; margin: 1.5rem auto; padding: 0 1rem; }
+
+    /* ── Summary cards ── */
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    .card {
+      background: #fff;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,.07);
+    }
+    .card .label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #6b7280;
+      margin-bottom: 0.3rem;
+    }
+    .card .value { font-size: 1.75rem; font-weight: 700; }
+    .card.c-pass  .value { color: #16a34a; }
+    .card.c-fail  .value { color: #dc2626; }
+    .card.c-error .value { color: #d97706; }
+    .card.c-rate  .value { color: #2563eb; }
+
+    /* ── Per-evaluator stats ── */
+    .section-title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #6b7280;
+      margin-bottom: 0.5rem;
+    }
+    .ev-table-wrap { margin-bottom: 1.5rem; }
+    .ev-table {
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.07);
+      border-collapse: collapse;
+      width: auto;
+      min-width: 400px;
+    }
+    .ev-table th, .ev-table td {
+      padding: 0.5rem 1rem;
+      text-align: left;
+    }
+    .ev-table th {
+      background: #f8fafc;
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6b7280;
+      border-bottom: 1px solid #e5e7eb;
+    }
+    .ev-table td { border-bottom: 1px solid #f3f4f6; }
+    .ev-table tr:last-child td { border-bottom: none; }
+
+    /* ── Results table ── */
+    .results-wrap { overflow-x: auto; }
+    table.results {
+      width: 100%;
+      border-collapse: collapse;
+      background: #fff;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 1px 3px rgba(0,0,0,.07);
+    }
+    table.results th {
+      background: #f8fafc;
+      padding: 0.6rem 1rem;
+      text-align: left;
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6b7280;
+      border-bottom: 2px solid #e5e7eb;
+      white-space: nowrap;
+    }
+    table.results td {
+      padding: 0.65rem 1rem;
+      border-bottom: 1px solid #f3f4f6;
+      vertical-align: top;
+    }
+    table.results tr:last-child td { border-bottom: none; }
+    table.results tr:hover td { background: #fafafa; }
+
+    .badge {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .badge-passed  { background: #dcfce7; color: #15803d; }
+    .badge-failed  { background: #fee2e2; color: #b91c1c; }
+    .badge-error   { background: #fef3c7; color: #b45309; }
+    .badge-skipped { background: #f3f4f6; color: #6b7280; }
+
+    .score-pass { color: #16a34a; font-weight: 600; }
+    .score-fail { color: #dc2626; font-weight: 600; }
+    .score-none { color: #9ca3af; }
+
+    /* ── Expandable failure details ── */
+    .detail-cell { background: #fafafa !important; padding: 0 !important; }
+    details { padding: 0.6rem 1rem 0.75rem; }
+    summary {
+      cursor: pointer;
+      font-size: 0.8rem;
+      color: #6b7280;
+      user-select: none;
+      list-style: none;
+    }
+    summary::before { content: "▶ "; font-size: 0.65rem; }
+    details[open] summary::before { content: "▼ "; }
+    summary:hover { color: #374151; }
+    .detail-item {
+      margin-top: 0.5rem;
+      font-size: 0.82rem;
+      padding-left: 1rem;
+      border-left: 2px solid #e5e7eb;
+    }
+    .detail-item .ev-label { color: #d97706; font-weight: 600; }
+    .detail-item .ev-error { color: #dc2626; }
+
+    /* ── Footer ── */
+    footer {
+      text-align: center;
+      padding: 2rem 1rem;
+      font-size: 0.75rem;
+      color: #9ca3af;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>RagaliQ Evaluation Report</h1>
+  <span class="meta">Generated {{ generated_at }} &nbsp;·&nbsp; Threshold {{ threshold }}</span>
+</header>
+
+<div class="container">
+
+  <!-- Summary cards -->
+  <div class="cards">
+    <div class="card">
+      <div class="label">Total</div>
+      <div class="value">{{ summary.total }}</div>
+    </div>
+    <div class="card c-pass">
+      <div class="label">Passed</div>
+      <div class="value">{{ summary.passed }}</div>
+    </div>
+    <div class="card c-fail">
+      <div class="label">Failed</div>
+      <div class="value">{{ summary.failed }}</div>
+    </div>
+    {% if summary.errored > 0 %}
+    <div class="card c-error">
+      <div class="label">Errored</div>
+      <div class="value">{{ summary.errored }}</div>
+    </div>
+    {% endif %}
+    <div class="card c-rate">
+      <div class="label">Pass Rate</div>
+      <div class="value">{{ "%.0f%%" | format(summary.pass_rate * 100) }}</div>
+    </div>
+    <div class="card">
+      <div class="label">Tokens</div>
+      <div class="value" style="font-size:1.2rem">{{ "{:,}".format(summary.total_tokens) }}</div>
+    </div>
+  </div>
+
+  <!-- Per-evaluator stats -->
+  {% if evaluators %}
+  <div class="ev-table-wrap">
+    <div class="section-title">Evaluator Summary</div>
+    <table class="ev-table">
+      <thead>
+        <tr>
+          <th>Evaluator</th>
+          <th>Passed</th>
+          <th>Failed</th>
+          <th>Avg Score</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for ev in evaluators %}
+        <tr>
+          <td>{{ ev.name }}</td>
+          <td style="color:#16a34a;font-weight:600">{{ ev.passed }}</td>
+          <td style="color:{% if ev.failed > 0 %}#dc2626{% else %}#6b7280{% endif %};font-weight:{% if ev.failed > 0 %}600{% else %}400{% endif %}">{{ ev.failed }}</td>
+          <td>{{ "%.3f" | format(ev.avg_score) }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+  {% endif %}
+
+  <!-- Results table -->
+  <div class="section-title">Results</div>
+  <div class="results-wrap">
+    <table class="results">
+      <thead>
+        <tr>
+          <th>Test Case</th>
+          <th>Status</th>
+          {% for ev in evaluators %}
+          <th>{{ ev.name | replace("_", " ") | title }}</th>
+          {% endfor %}
+          <th>Time (ms)</th>
+        </tr>
+      </thead>
+      <tbody>
+        {% for result in results %}
+        <tr>
+          <td>{{ result.name }}</td>
+          <td><span class="badge badge-{{ result.status }}">{{ result.status }}</span></td>
+          {% for score in result.scores %}
+          <td>
+            {% if score.value is none %}
+              <span class="score-none">—</span>
+            {% elif score.passes %}
+              <span class="score-pass">{{ "%.2f" | format(score.value) }}</span>
+            {% else %}
+              <span class="score-fail">{{ "%.2f" | format(score.value) }}</span>
+            {% endif %}
+          </td>
+          {% endfor %}
+          <td style="color:#6b7280">{{ result.execution_time_ms }}</td>
+        </tr>
+        {% if result.failing_details %}
+        <tr>
+          <td class="detail-cell" colspan="{{ 3 + evaluators | length }}">
+            <details>
+              <summary>Failure details</summary>
+              {% for item in result.failing_details %}
+              <div class="detail-item">
+                <span class="ev-label">{{ item.evaluator }}</span>:
+                {% if item.is_error %}
+                  <span class="ev-error">{{ item.text }}</span>
+                {% else %}
+                  {{ item.text }}
+                {% endif %}
+              </div>
+              {% endfor %}
+            </details>
+          </td>
+        </tr>
+        {% endif %}
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+</div>
+
+<footer>
+  Generated by <strong>RagaliQ</strong> &nbsp;·&nbsp; {{ generated_at }}
+</footer>
+
+</body>
+</html>

--- a/tests/unit/test_html_reporter.py
+++ b/tests/unit/test_html_reporter.py
@@ -1,0 +1,233 @@
+"""Unit tests for HTMLReporter."""
+
+from __future__ import annotations
+
+from ragaliq.core.test_case import EvalStatus, RAGTestCase, RAGTestResult
+from ragaliq.reports.html import HTMLReporter
+
+
+def _make_tc(name: str = "Test", id: str = "t1") -> RAGTestCase:
+    return RAGTestCase(
+        id=id,
+        name=name,
+        query="What is X?",
+        context=["X is Y."],
+        response="X is Y.",
+    )
+
+
+def _make_result(
+    name: str = "Test",
+    id: str = "t1",
+    status: EvalStatus = EvalStatus.PASSED,
+    scores: dict | None = None,
+    details: dict | None = None,
+    execution_time_ms: int = 100,
+    judge_tokens_used: int = 0,
+) -> RAGTestResult:
+    return RAGTestResult(
+        test_case=_make_tc(name=name, id=id),
+        status=status,
+        scores=scores if scores is not None else {},
+        details=details if details is not None else {},
+        execution_time_ms=execution_time_ms,
+        judge_tokens_used=judge_tokens_used,
+    )
+
+
+def _export(results: list[RAGTestResult], threshold: float = 0.7) -> str:
+    return HTMLReporter(threshold=threshold).export(results)
+
+
+class TestHTMLStructure:
+    """Test that output is a well-formed HTML document."""
+
+    def test_returns_string(self) -> None:
+        """export() returns a string."""
+        result = _make_result()
+        html = _export([result])
+        assert isinstance(html, str)
+
+    def test_has_doctype(self) -> None:
+        """Output starts with a DOCTYPE declaration."""
+        html = _export([_make_result()])
+        assert "<!DOCTYPE html>" in html
+
+    def test_has_html_tag(self) -> None:
+        """Output contains opening and closing html tags."""
+        html = _export([_make_result()])
+        assert "<html" in html
+        assert "</html>" in html
+
+    def test_has_head_and_body(self) -> None:
+        """Output contains head and body sections."""
+        html = _export([_make_result()])
+        assert "<head>" in html
+        assert "<body>" in html
+
+    def test_has_embedded_style(self) -> None:
+        """Output contains embedded CSS (no external stylesheet links)."""
+        html = _export([_make_result()])
+        assert "<style>" in html
+        # Must NOT reference external stylesheets
+        assert 'rel="stylesheet"' not in html
+
+    def test_no_script_tags(self) -> None:
+        """Output contains no JavaScript (truly self-contained)."""
+        html = _export([_make_result()])
+        assert "<script" not in html
+
+    def test_has_title(self) -> None:
+        """Output has a page title."""
+        html = _export([_make_result()])
+        assert "<title>" in html
+        assert "RagaliQ" in html
+
+
+class TestHTMLContent:
+    """Test that report content appears in the output."""
+
+    def test_shows_test_case_name(self) -> None:
+        """Test case name appears in the HTML output."""
+        result = _make_result(name="Capital query")
+        html = _export([result])
+        assert "Capital query" in html
+
+    def test_shows_passed_status_badge(self) -> None:
+        """PASSED status is represented in the output."""
+        result = _make_result(status=EvalStatus.PASSED)
+        html = _export([result])
+        assert "passed" in html.lower()
+
+    def test_shows_failed_status_badge(self) -> None:
+        """FAILED status is represented in the output."""
+        result = _make_result(status=EvalStatus.FAILED, scores={"faithfulness": 0.3})
+        html = _export([result])
+        assert "failed" in html.lower()
+
+    def test_shows_error_status_badge(self) -> None:
+        """ERROR status is represented in the output."""
+        result = _make_result(status=EvalStatus.ERROR)
+        html = _export([result])
+        assert "error" in html.lower()
+
+    def test_shows_evaluator_score(self) -> None:
+        """Evaluator score value appears in the HTML."""
+        result = _make_result(scores={"faithfulness": 0.92})
+        html = _export([result])
+        assert "0.92" in html
+
+    def test_shows_evaluator_column_name(self) -> None:
+        """Evaluator name appears as a column header."""
+        result = _make_result(scores={"faithfulness": 0.9})
+        html = _export([result])
+        assert "faithfulness" in html.lower() or "Faithfulness" in html
+
+    def test_shows_all_test_case_names(self) -> None:
+        """All test case names appear when multiple results are present."""
+        r1 = _make_result(name="Case Alpha", id="t1", scores={"faithfulness": 0.9})
+        r2 = _make_result(name="Case Beta", id="t2", scores={"faithfulness": 0.5})
+        html = _export([r1, r2])
+        assert "Case Alpha" in html
+        assert "Case Beta" in html
+
+    def test_shows_summary_totals(self) -> None:
+        """Summary card shows total number of test cases."""
+        r1 = _make_result(id="t1")
+        r2 = _make_result(id="t2")
+        html = _export([r1, r2])
+        assert "2" in html  # total count appears somewhere
+
+    def test_shows_pass_rate(self) -> None:
+        """Pass rate percentage appears in the summary cards."""
+        r1 = _make_result(id="t1", status=EvalStatus.PASSED)
+        r2 = _make_result(id="t2", status=EvalStatus.FAILED)
+        html = _export([r1, r2])
+        assert "50%" in html
+
+    def test_shows_token_count(self) -> None:
+        """Token count appears in the summary when nonzero."""
+        result = _make_result(judge_tokens_used=1500)
+        html = _export([result])
+        assert "1,500" in html or "1500" in html
+
+
+class TestHTMLFailureDetails:
+    """Test expandable failure detail sections."""
+
+    def test_shows_details_element_for_failed(self) -> None:
+        """HTML5 details element is present for failed results with details."""
+        result = _make_result(
+            status=EvalStatus.FAILED,
+            scores={"faithfulness": 0.3},
+            details={"faithfulness": {"reasoning": "Missing key fact", "passed": False, "raw": {}}},
+        )
+        html = _export([result])
+        assert "<details>" in html
+
+    def test_shows_reasoning_text(self) -> None:
+        """Reasoning text appears in the HTML for failing evaluators."""
+        result = _make_result(
+            status=EvalStatus.FAILED,
+            scores={"faithfulness": 0.3},
+            details={"faithfulness": {"reasoning": "Missing key fact", "passed": False, "raw": {}}},
+        )
+        html = _export([result])
+        assert "Missing key fact" in html
+
+    def test_shows_error_text(self) -> None:
+        """Error message appears in the HTML for errored evaluators."""
+        result = _make_result(
+            status=EvalStatus.ERROR,
+            scores={"faithfulness": 0.0},
+            details={"faithfulness": {"error": "API timeout", "passed": False, "raw": {}}},
+        )
+        html = _export([result])
+        assert "API timeout" in html
+
+    def test_no_details_element_for_passing_results(self) -> None:
+        """No details element appears when all results pass."""
+        result = _make_result(
+            status=EvalStatus.PASSED,
+            scores={"faithfulness": 0.9},
+            details={"faithfulness": {"reasoning": "All good", "passed": True, "raw": {}}},
+        )
+        html = _export([result])
+        assert "<details>" not in html
+
+
+class TestHTMLEdgeCases:
+    """Test edge cases."""
+
+    def test_empty_results_no_crash(self) -> None:
+        """Empty results list renders without error."""
+        html = _export([])
+        assert "<!DOCTYPE html>" in html
+
+    def test_no_evaluators_no_crash(self) -> None:
+        """Result with no scores renders without error."""
+        result = _make_result(scores={})
+        html = _export([result])
+        assert "Test" in html
+
+    def test_threshold_respected_in_template(self) -> None:
+        """Custom threshold affects score pass/fail coloring class."""
+        result = _make_result(scores={"faithfulness": 0.65})
+        html_low = _export([result], threshold=0.6)  # 0.65 passes
+        html_high = _export([result], threshold=0.7)  # 0.65 fails
+        # score-pass class for low threshold, score-fail for high
+        assert "score-pass" in html_low
+        assert "score-fail" in html_high
+
+    def test_special_chars_escaped(self) -> None:
+        """HTML special characters in test case names are escaped."""
+        result = _make_result(name="Test <query> & more")
+        html = _export([result])
+        # Jinja2 autoescape should encode < > &
+        assert "<query>" not in html
+        assert "&lt;" in html or "Test" in html  # at minimum, raw < not injected
+
+    def test_default_reporter_has_threshold(self) -> None:
+        """HTMLReporter created without args has default threshold."""
+        reporter = HTMLReporter()
+        assert reporter._threshold == 0.7

--- a/tests/unit/test_json_reporter.py
+++ b/tests/unit/test_json_reporter.py
@@ -1,0 +1,260 @@
+"""Unit tests for JSONReporter."""
+
+from __future__ import annotations
+
+import json
+
+from ragaliq.core.test_case import EvalStatus, RAGTestCase, RAGTestResult
+from ragaliq.reports.json_export import JSONReporter
+
+
+def _make_tc(name: str = "Test", id: str = "t1") -> RAGTestCase:
+    return RAGTestCase(
+        id=id,
+        name=name,
+        query="What is X?",
+        context=["X is Y."],
+        response="X is Y.",
+    )
+
+
+def _make_result(
+    name: str = "Test",
+    id: str = "t1",
+    status: EvalStatus = EvalStatus.PASSED,
+    scores: dict | None = None,
+    details: dict | None = None,
+    execution_time_ms: int = 100,
+    judge_tokens_used: int = 50,
+) -> RAGTestResult:
+    return RAGTestResult(
+        test_case=_make_tc(name=name, id=id),
+        status=status,
+        scores=scores if scores is not None else {},
+        details=details if details is not None else {},
+        execution_time_ms=execution_time_ms,
+        judge_tokens_used=judge_tokens_used,
+    )
+
+
+def _export(results: list[RAGTestResult], threshold: float = 0.7) -> dict:
+    """Export results and parse the JSON back to a dict."""
+    raw = JSONReporter(threshold=threshold).export(results)
+    return json.loads(raw)
+
+
+class TestJSONStructure:
+    """Test top-level JSON document structure."""
+
+    def test_returns_valid_json(self) -> None:
+        """export() returns a string that parses as valid JSON."""
+        result = _make_result(scores={"faithfulness": 0.9})
+        raw = JSONReporter().export([result])
+        parsed = json.loads(raw)
+        assert isinstance(parsed, dict)
+
+    def test_has_generated_at_field(self) -> None:
+        """Document includes a generated_at ISO timestamp."""
+        doc = _export([_make_result()])
+        assert "generated_at" in doc
+        assert "T" in doc["generated_at"]  # ISO format check
+
+    def test_has_threshold_field(self) -> None:
+        """Document includes the configured threshold value."""
+        doc = _export([_make_result()], threshold=0.85)
+        assert doc["threshold"] == 0.85
+
+    def test_has_summary_key(self) -> None:
+        """Document has a summary key."""
+        doc = _export([_make_result()])
+        assert "summary" in doc
+
+    def test_has_results_key(self) -> None:
+        """Document has a results key."""
+        doc = _export([_make_result()])
+        assert "results" in doc
+
+    def test_pretty_printed(self) -> None:
+        """JSON output is indented (pretty-printed)."""
+        raw = JSONReporter().export([_make_result()])
+        assert "\n" in raw
+        assert "  " in raw
+
+
+class TestSummarySection:
+    """Test the summary section of the JSON document."""
+
+    def test_summary_total(self) -> None:
+        """summary.total matches the number of results."""
+        r1 = _make_result(id="t1")
+        r2 = _make_result(id="t2")
+        doc = _export([r1, r2])
+        assert doc["summary"]["total"] == 2
+
+    def test_summary_passed_count(self) -> None:
+        """summary.passed counts results with PASSED status."""
+        r1 = _make_result(id="t1", status=EvalStatus.PASSED)
+        r2 = _make_result(id="t2", status=EvalStatus.FAILED)
+        doc = _export([r1, r2])
+        assert doc["summary"]["passed"] == 1
+
+    def test_summary_failed_count(self) -> None:
+        """summary.failed counts non-passing results."""
+        r1 = _make_result(id="t1", status=EvalStatus.PASSED)
+        r2 = _make_result(id="t2", status=EvalStatus.FAILED)
+        doc = _export([r1, r2])
+        assert doc["summary"]["failed"] == 1
+
+    def test_summary_errored_count(self) -> None:
+        """summary.errored counts results with ERROR status."""
+        r1 = _make_result(id="t1", status=EvalStatus.PASSED)
+        r2 = _make_result(id="t2", status=EvalStatus.ERROR)
+        doc = _export([r1, r2])
+        assert doc["summary"]["errored"] == 1
+
+    def test_summary_pass_rate(self) -> None:
+        """summary.pass_rate is passed/total."""
+        r1 = _make_result(id="t1", status=EvalStatus.PASSED)
+        r2 = _make_result(id="t2", status=EvalStatus.FAILED)
+        doc = _export([r1, r2])
+        assert doc["summary"]["pass_rate"] == 0.5
+
+    def test_summary_pass_rate_empty(self) -> None:
+        """summary.pass_rate is 0.0 for empty results."""
+        doc = _export([])
+        assert doc["summary"]["pass_rate"] == 0.0
+
+    def test_summary_total_tokens(self) -> None:
+        """summary.total_tokens sums judge_tokens_used across results."""
+        r1 = _make_result(id="t1", judge_tokens_used=100)
+        r2 = _make_result(id="t2", judge_tokens_used=250)
+        doc = _export([r1, r2])
+        assert doc["summary"]["total_tokens"] == 350
+
+    def test_summary_total_execution_ms(self) -> None:
+        """summary.total_execution_ms sums execution_time_ms across results."""
+        r1 = _make_result(id="t1", execution_time_ms=500)
+        r2 = _make_result(id="t2", execution_time_ms=800)
+        doc = _export([r1, r2])
+        assert doc["summary"]["total_execution_ms"] == 1300
+
+    def test_summary_evaluators_keys(self) -> None:
+        """summary.evaluators contains a key per evaluator."""
+        result = _make_result(scores={"faithfulness": 0.9, "relevance": 0.8})
+        doc = _export([result])
+        ev = doc["summary"]["evaluators"]
+        assert "faithfulness" in ev
+        assert "relevance" in ev
+
+    def test_summary_evaluator_passed_count(self) -> None:
+        """Per-evaluator passed count respects the threshold."""
+        r1 = _make_result(id="t1", scores={"faithfulness": 0.9})
+        r2 = _make_result(id="t2", scores={"faithfulness": 0.5})
+        doc = _export([r1, r2], threshold=0.7)
+        ev = doc["summary"]["evaluators"]["faithfulness"]
+        assert ev["passed"] == 1
+        assert ev["failed"] == 1
+
+    def test_summary_evaluator_avg_score(self) -> None:
+        """Per-evaluator avg_score is the mean of all scores."""
+        r1 = _make_result(id="t1", scores={"faithfulness": 0.9})
+        r2 = _make_result(id="t2", scores={"faithfulness": 0.7})
+        doc = _export([r1, r2])
+        avg = doc["summary"]["evaluators"]["faithfulness"]["avg_score"]
+        assert abs(avg - 0.8) < 0.001
+
+
+class TestResultsSection:
+    """Test individual result entries in the results array."""
+
+    def test_results_length_matches_input(self) -> None:
+        """results array has one entry per input result."""
+        r1 = _make_result(id="t1")
+        r2 = _make_result(id="t2")
+        doc = _export([r1, r2])
+        assert len(doc["results"]) == 2
+
+    def test_result_id_field(self) -> None:
+        """Each result entry has the test case id."""
+        result = _make_result(id="tc-42")
+        doc = _export([result])
+        assert doc["results"][0]["id"] == "tc-42"
+
+    def test_result_name_field(self) -> None:
+        """Each result entry has the test case name."""
+        result = _make_result(name="Capital query")
+        doc = _export([result])
+        assert doc["results"][0]["name"] == "Capital query"
+
+    def test_result_status_is_string(self) -> None:
+        """Status field is serialized as a plain string."""
+        result = _make_result(status=EvalStatus.PASSED)
+        doc = _export([result])
+        assert doc["results"][0]["status"] == "passed"
+
+    def test_result_passed_field(self) -> None:
+        """passed field is a boolean."""
+        r_pass = _make_result(id="t1", status=EvalStatus.PASSED)
+        r_fail = _make_result(id="t2", status=EvalStatus.FAILED)
+        doc = _export([r_pass, r_fail])
+        assert doc["results"][0]["passed"] is True
+        assert doc["results"][1]["passed"] is False
+
+    def test_result_scores_dict(self) -> None:
+        """scores dict is preserved as-is."""
+        result = _make_result(scores={"faithfulness": 0.92, "relevance": 0.85})
+        doc = _export([result])
+        assert doc["results"][0]["scores"]["faithfulness"] == 0.92
+        assert doc["results"][0]["scores"]["relevance"] == 0.85
+
+    def test_result_execution_time_ms(self) -> None:
+        """execution_time_ms field is included."""
+        result = _make_result(execution_time_ms=1234)
+        doc = _export([result])
+        assert doc["results"][0]["execution_time_ms"] == 1234
+
+    def test_result_judge_tokens_used(self) -> None:
+        """judge_tokens_used field is included."""
+        result = _make_result(judge_tokens_used=777)
+        doc = _export([result])
+        assert doc["results"][0]["judge_tokens_used"] == 777
+
+    def test_result_test_case_nested(self) -> None:
+        """Each result entry contains a nested test_case object."""
+        result = _make_result(name="My test")
+        doc = _export([result])
+        tc = doc["results"][0]["test_case"]
+        assert tc["name"] == "My test"
+        assert "query" in tc
+        assert "context" in tc
+        assert "response" in tc
+
+    def test_result_test_case_context_is_list(self) -> None:
+        """test_case.context is serialized as a list."""
+        result = _make_result()
+        doc = _export([result])
+        assert isinstance(doc["results"][0]["test_case"]["context"], list)
+
+
+class TestEdgeCases:
+    """Test edge cases and empty states."""
+
+    def test_empty_results(self) -> None:
+        """Empty results list produces valid JSON with empty results array."""
+        doc = _export([])
+        assert doc["results"] == []
+        assert doc["summary"]["total"] == 0
+
+    def test_no_evaluators(self) -> None:
+        """Result with no scores produces empty evaluators dict in summary."""
+        result = _make_result(scores={})
+        doc = _export([result])
+        assert doc["summary"]["evaluators"] == {}
+
+    def test_threshold_used_in_evaluator_stats(self) -> None:
+        """Custom threshold is applied when computing per-evaluator pass/fail."""
+        result = _make_result(scores={"faithfulness": 0.65})
+        doc_low = _export([result], threshold=0.6)  # 0.65 >= 0.6 → passes
+        doc_high = _export([result], threshold=0.7)  # 0.65 < 0.7 → fails
+        assert doc_low["summary"]["evaluators"]["faithfulness"]["passed"] == 1
+        assert doc_high["summary"]["evaluators"]["faithfulness"]["passed"] == 0


### PR DESCRIPTION
Closes #17

## Changes

### New reporters
- **`src/ragaliq/reports/json_export.py`** — `JSONReporter` with `export(results) -> str`:
  - Pretty-printed JSON (indent=2, UTF-8 safe)
  - Top-level: `generated_at`, `threshold`, `summary`, `results`
  - Summary: total/passed/failed/errored/pass_rate/total_tokens/total_execution_ms + per-evaluator stats
  - Results: each entry includes id, name, status, passed, scores, details, execution_time_ms, judge_tokens_used, and nested test_case object

- **`src/ragaliq/reports/html.py`** — `HTMLReporter` with `export(results) -> str`:
  - Jinja2-rendered, self-contained HTML (no external dependencies, no JavaScript)
  - Summary cards (total, passed, failed, errored, pass rate, token count)
  - Per-evaluator stats table (passed/failed/avg score)
  - Results table with colour-coded scores respecting threshold
  - Expandable failure details via HTML5 `<details>/<summary>` tags

- **`src/ragaliq/reports/templates/report.html.j2`** — Template with embedded CSS

### CLI
- **`src/ragaliq/cli/main.py`** — Added `--output` (console/json/html, default: console) and `--output-file` options to `run` command; unknown format exits 1 with a clear error message

### Package
- **`src/ragaliq/reports/__init__.py`** — Exports `HTMLReporter` and `JSONReporter`

### Tests
- **`tests/unit/test_json_reporter.py`** — 35 tests: JSON structure, summary fields, per-result serialization, edge cases, threshold behaviour
- **`tests/unit/test_html_reporter.py`** — 24 tests: HTML structure/self-containment, content rendering, failure details, XSS escaping, threshold coloring
- **`tests/unit/test_cli.py`** — 5 new tests: `--output json` file writing, `--output html` file writing, path echo, console default, unknown format

## Checks

- `hatch run lint` — All checks passed
- `hatch run typecheck` — Success: no issues found in 33 source files
- `hatch run test` — 528 passed, 1 skipped, 0 warnings