### PR TITLE
[FEAT #18] Task 17: GitHub Actions Integration

### DIFF
--- a/examples/ci_cd_example/README.md
+++ b/examples/ci_cd_example/README.md
@@ -1,0 +1,19 @@
+# CI/CD Example
+
+Example GitHub Actions workflow for running RagaliQ evaluations in CI.
+
+## Setup
+
+1. Copy `ragaliq-ci.yml` to `.github/workflows/` in your repository
+2. Add your `ANTHROPIC_API_KEY` as a repository secret
+3. Place your dataset at `datasets/test_cases.json` (or update the path in the workflow)
+
+## Features
+
+When running in GitHub Actions, RagaliQ automatically:
+
+- **Disables Rich output** — no animated spinners cluttering CI logs
+- **Writes a step summary** — Markdown results table visible in the Actions run UI
+- **Creates annotations** — failing test cases appear as error annotations on PR diffs
+- **Sets step outputs** — `total`, `passed`, `failed`, `pass_rate` available for downstream steps
+- **Exits with code 1** on any failure — blocks merging when used as a required check

--- a/examples/ci_cd_example/ragaliq-ci.yml
+++ b/examples/ci_cd_example/ragaliq-ci.yml
@@ -1,0 +1,54 @@
+# Example GitHub Actions workflow for running RagaliQ evaluations.
+#
+# Copy this file to .github/workflows/ragaliq-ci.yml in your repository.
+# Requires an ANTHROPIC_API_KEY secret configured in your repository settings.
+#
+# What it does:
+#   1. Checks out code and installs RagaliQ
+#   2. Runs evaluations against your dataset
+#   3. Writes a Markdown step summary visible in the Actions run UI
+#   4. Creates annotations on pull-request diffs for failing test cases
+#   5. Uploads the JSON report as a workflow artifact
+
+name: RagaliQ Evaluation
+
+on:
+  pull_request:
+    paths:
+      - "datasets/**"
+      - "src/**"
+  workflow_dispatch:  # Allow manual runs
+
+permissions:
+  contents: read
+  checks: write
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install RagaliQ
+        run: pip install ragaliq
+
+      - name: Run evaluations
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          ragaliq run datasets/test_cases.json \
+            --output json \
+            --output-file report.json \
+            --threshold 0.7
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ragaliq-report
+          path: report.json

--- a/src/ragaliq/integrations/__init__.py
+++ b/src/ragaliq/integrations/__init__.py
@@ -1,1 +1,21 @@
-# Integrations package (pytest plugin, etc.)
+# Integrations package (pytest plugin, GitHub Actions helpers, etc.)
+
+from ragaliq.integrations.github_actions import (
+    create_annotations,
+    emit_ci_summary,
+    format_summary_markdown,
+    is_ci,
+    is_github_actions,
+    set_output,
+    write_step_summary,
+)
+
+__all__ = [
+    "create_annotations",
+    "emit_ci_summary",
+    "format_summary_markdown",
+    "is_ci",
+    "is_github_actions",
+    "set_output",
+    "write_step_summary",
+]

--- a/src/ragaliq/integrations/github_actions.py
+++ b/src/ragaliq/integrations/github_actions.py
@@ -1,0 +1,180 @@
+"""GitHub Actions integration helpers for RagaliQ.
+
+Provides CI environment detection, workflow command output (annotations,
+step summaries, outputs), and a Markdown summary formatter for evaluation
+results.  All helpers are safe to call outside GitHub Actions — they
+degrade gracefully (return ``False`` or silently skip writes).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ragaliq.core.test_case import RAGTestResult
+
+
+def is_ci() -> bool:
+    """Detect whether the process is running inside any CI system.
+
+    Returns:
+        ``True`` when the ``CI`` environment variable is set to a truthy value.
+    """
+    return os.environ.get("CI", "").lower() in {"true", "1", "yes"}
+
+
+def is_github_actions() -> bool:
+    """Detect whether the process is running inside GitHub Actions.
+
+    Returns:
+        ``True`` when the ``GITHUB_ACTIONS`` environment variable equals ``"true"``.
+    """
+    return os.environ.get("GITHUB_ACTIONS", "").lower() == "true"
+
+
+def set_output(name: str, value: str) -> None:
+    """Write a key-value pair to the ``$GITHUB_OUTPUT`` file.
+
+    In GitHub Actions, subsequent steps can read this value with
+    ``${{ steps.<id>.outputs.<name> }}``.  Outside Actions this is a no-op.
+
+    Args:
+        name: Output parameter name.
+        value: Output parameter value (multi-line values are supported via
+            the heredoc protocol, but this helper uses the single-line form).
+    """
+    path = os.environ.get("GITHUB_OUTPUT")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(f"{name}={value}\n")
+
+
+def write_step_summary(markdown: str) -> None:
+    """Append Markdown content to the GitHub Actions step summary.
+
+    The rendered Markdown appears in the workflow run UI below the step log.
+    Outside Actions this is a no-op.
+
+    Args:
+        markdown: Markdown-formatted string to append.
+    """
+    path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not path:
+        return
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write(markdown)
+        if not markdown.endswith("\n"):
+            fh.write("\n")
+
+
+def create_annotations(
+    results: list[RAGTestResult],
+    threshold: float = 0.7,
+) -> None:
+    """Emit GitHub Actions annotations for failed or errored test cases.
+
+    Each failing result produces an ``::error::`` workflow command written
+    to *stdout*.  GitHub Actions parses these and surfaces them in the
+    workflow run UI and on pull-request diffs.
+
+    Args:
+        results: Evaluation results to inspect.
+        threshold: Score threshold used for pass/fail classification.
+    """
+    for result in results:
+        if result.passed:
+            continue
+
+        tc = result.test_case
+        failing = [
+            f"{metric}={score:.2f}" for metric, score in result.scores.items() if score < threshold
+        ]
+        detail = ", ".join(failing) if failing else f"status={result.status}"
+        message = f"RagaliQ: '{tc.name}' failed — {detail}"
+
+        # Escape characters that break the workflow command protocol
+        safe_msg = message.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+        print(f"::error::{safe_msg}", flush=True)  # noqa: T201
+
+
+def format_summary_markdown(
+    results: list[RAGTestResult],
+    threshold: float = 0.7,
+) -> str:
+    """Build a Markdown summary table suitable for ``write_step_summary()``.
+
+    Args:
+        results: Evaluation results to summarize.
+        threshold: Score threshold for pass/fail classification.
+
+    Returns:
+        A Markdown string with a header, summary stats, and a results table.
+    """
+    total = len(results)
+    passed = sum(1 for r in results if r.passed)
+    failed = total - passed
+
+    lines: list[str] = [
+        "## RagaliQ Evaluation Results\n",
+        f"**{passed}/{total}** test cases passed ({failed} failed) — threshold: {threshold}\n",
+    ]
+
+    if not results:
+        return "\n".join(lines)
+
+    # Collect evaluator names from the first result
+    evaluator_names = sorted(results[0].scores.keys()) if results[0].scores else []
+
+    # --- Results table ---
+    header_cols = ["Test Case", "Status"] + evaluator_names
+    lines.append("| " + " | ".join(header_cols) + " |")
+    lines.append("| " + " | ".join("---" for _ in header_cols) + " |")
+
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        score_cells = [f"{r.scores.get(ev, 0.0):.2f}" for ev in evaluator_names]
+        row = [r.test_case.name, status, *score_cells]
+        lines.append("| " + " | ".join(row) + " |")
+
+    lines.append("")  # trailing newline
+    return "\n".join(lines)
+
+
+def emit_ci_summary(
+    results: list[RAGTestResult],
+    threshold: float = 0.7,
+) -> None:
+    """High-level helper: write step summary + annotations in one call.
+
+    Intended to be called from the CLI ``run`` command when GitHub Actions
+    is detected.  Safe to call outside Actions (both sub-calls are no-ops).
+
+    Args:
+        results: Evaluation results.
+        threshold: Score threshold for pass/fail classification.
+    """
+    write_step_summary(format_summary_markdown(results, threshold=threshold))
+    create_annotations(results, threshold=threshold)
+
+    # Set outputs for downstream steps
+    total = len(results)
+    passed = sum(1 for r in results if r.passed)
+    set_output("total", str(total))
+    set_output("passed", str(passed))
+    set_output("failed", str(total - passed))
+    set_output("pass_rate", f"{passed / total:.4f}" if total else "0.0000")
+
+
+def ci_print(message: str) -> None:
+    """Print a plain-text message suitable for CI log output.
+
+    Uses ``sys.stdout`` directly to avoid Rich markup processing.
+
+    Args:
+        message: Text to print.
+    """
+    sys.stdout.write(message + "\n")
+    sys.stdout.flush()

--- a/tests/unit/test_github_actions.py
+++ b/tests/unit/test_github_actions.py
@@ -1,0 +1,343 @@
+"""Unit tests for GitHub Actions integration helpers."""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+from ragaliq.core.test_case import EvalStatus, RAGTestCase, RAGTestResult
+from ragaliq.integrations.github_actions import (
+    create_annotations,
+    emit_ci_summary,
+    format_summary_markdown,
+    is_ci,
+    is_github_actions,
+    set_output,
+    write_step_summary,
+)
+
+
+def _make_tc(name: str = "Test", id: str = "t1") -> RAGTestCase:
+    return RAGTestCase(
+        id=id,
+        name=name,
+        query="What is X?",
+        context=["X is Y."],
+        response="X is Y.",
+    )
+
+
+def _make_result(
+    name: str = "Test",
+    id: str = "t1",
+    status: EvalStatus = EvalStatus.PASSED,
+    scores: dict | None = None,
+) -> RAGTestResult:
+    return RAGTestResult(
+        test_case=_make_tc(name=name, id=id),
+        status=status,
+        scores=scores if scores is not None else {"faithfulness": 0.9},
+        details={},
+    )
+
+
+# ---------------------------------------------------------------------------
+# CI Detection
+# ---------------------------------------------------------------------------
+
+
+class TestIsCI:
+    """Test is_ci() environment detection."""
+
+    def test_true_when_ci_is_true(self) -> None:
+        """Returns True when CI=true."""
+        with patch.dict(os.environ, {"CI": "true"}):
+            assert is_ci() is True
+
+    def test_true_when_ci_is_one(self) -> None:
+        """Returns True when CI=1."""
+        with patch.dict(os.environ, {"CI": "1"}):
+            assert is_ci() is True
+
+    def test_true_when_ci_is_yes(self) -> None:
+        """Returns True when CI=yes."""
+        with patch.dict(os.environ, {"CI": "yes"}):
+            assert is_ci() is True
+
+    def test_true_case_insensitive(self) -> None:
+        """Returns True when CI=TRUE (uppercase)."""
+        with patch.dict(os.environ, {"CI": "TRUE"}):
+            assert is_ci() is True
+
+    def test_false_when_unset(self) -> None:
+        """Returns False when CI is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert is_ci() is False
+
+    def test_false_when_empty(self) -> None:
+        """Returns False when CI is empty string."""
+        with patch.dict(os.environ, {"CI": ""}):
+            assert is_ci() is False
+
+    def test_false_when_false(self) -> None:
+        """Returns False when CI=false."""
+        with patch.dict(os.environ, {"CI": "false"}):
+            assert is_ci() is False
+
+
+class TestIsGitHubActions:
+    """Test is_github_actions() environment detection."""
+
+    def test_true_when_github_actions_is_true(self) -> None:
+        """Returns True when GITHUB_ACTIONS=true."""
+        with patch.dict(os.environ, {"GITHUB_ACTIONS": "true"}):
+            assert is_github_actions() is True
+
+    def test_true_case_insensitive(self) -> None:
+        """Returns True when GITHUB_ACTIONS=True (mixed case)."""
+        with patch.dict(os.environ, {"GITHUB_ACTIONS": "True"}):
+            assert is_github_actions() is True
+
+    def test_false_when_unset(self) -> None:
+        """Returns False when GITHUB_ACTIONS is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            assert is_github_actions() is False
+
+    def test_false_when_empty(self) -> None:
+        """Returns False when GITHUB_ACTIONS is empty."""
+        with patch.dict(os.environ, {"GITHUB_ACTIONS": ""}):
+            assert is_github_actions() is False
+
+
+# ---------------------------------------------------------------------------
+# set_output
+# ---------------------------------------------------------------------------
+
+
+class TestSetOutput:
+    """Test set_output() writing to GITHUB_OUTPUT file."""
+
+    def test_writes_name_value_pair(self) -> None:
+        """Writes name=value line to the GITHUB_OUTPUT file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            path = f.name
+        try:
+            with patch.dict(os.environ, {"GITHUB_OUTPUT": path}):
+                set_output("result", "pass")
+            content = Path(path).read_text(encoding="utf-8")
+            assert "result=pass\n" in content
+        finally:
+            os.unlink(path)
+
+    def test_appends_multiple_outputs(self) -> None:
+        """Multiple calls append to the same file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+            path = f.name
+        try:
+            with patch.dict(os.environ, {"GITHUB_OUTPUT": path}):
+                set_output("a", "1")
+                set_output("b", "2")
+            content = Path(path).read_text(encoding="utf-8")
+            assert "a=1\n" in content
+            assert "b=2\n" in content
+        finally:
+            os.unlink(path)
+
+    def test_noop_when_env_unset(self) -> None:
+        """Does nothing when GITHUB_OUTPUT is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            set_output("key", "value")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# write_step_summary
+# ---------------------------------------------------------------------------
+
+
+class TestWriteStepSummary:
+    """Test write_step_summary() writing to GITHUB_STEP_SUMMARY file."""
+
+    def test_writes_markdown_content(self) -> None:
+        """Writes markdown to the GITHUB_STEP_SUMMARY file."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            path = f.name
+        try:
+            with patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": path}):
+                write_step_summary("## Results\n\nAll passed!")
+            content = Path(path).read_text(encoding="utf-8")
+            assert "## Results" in content
+            assert "All passed!" in content
+        finally:
+            os.unlink(path)
+
+    def test_appends_trailing_newline(self) -> None:
+        """Ensures content ends with a newline."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as f:
+            path = f.name
+        try:
+            with patch.dict(os.environ, {"GITHUB_STEP_SUMMARY": path}):
+                write_step_summary("no trailing newline")
+            content = Path(path).read_text(encoding="utf-8")
+            assert content.endswith("\n")
+        finally:
+            os.unlink(path)
+
+    def test_noop_when_env_unset(self) -> None:
+        """Does nothing when GITHUB_STEP_SUMMARY is not set."""
+        with patch.dict(os.environ, {}, clear=True):
+            write_step_summary("anything")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# create_annotations
+# ---------------------------------------------------------------------------
+
+
+class TestCreateAnnotations:
+    """Test create_annotations() workflow command output."""
+
+    def test_no_output_for_passing_results(self, capsys: object) -> None:
+        """No annotations emitted when all results pass."""
+        results = [_make_result(status=EvalStatus.PASSED, scores={"faithfulness": 0.9})]
+        create_annotations(results, threshold=0.7)
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        assert "::error::" not in out
+
+    def test_emits_error_for_failing_result(self, capsys: object) -> None:
+        """Emits ::error:: annotation for a failing result."""
+        results = [
+            _make_result(
+                name="bad-test",
+                status=EvalStatus.FAILED,
+                scores={"faithfulness": 0.3},
+            )
+        ]
+        create_annotations(results, threshold=0.7)
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        assert "::error::" in out
+        assert "bad-test" in out
+
+    def test_includes_failing_scores_in_message(self, capsys: object) -> None:
+        """Annotation message includes the failing metric scores."""
+        results = [
+            _make_result(
+                status=EvalStatus.FAILED,
+                scores={"faithfulness": 0.3, "relevance": 0.4},
+            )
+        ]
+        create_annotations(results, threshold=0.7)
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        assert "faithfulness=0.30" in out
+        assert "relevance=0.40" in out
+
+    def test_skips_passing_in_mixed_batch(self, capsys: object) -> None:
+        """Only emits annotations for failing results in a mixed batch."""
+        results = [
+            _make_result(id="t1", status=EvalStatus.PASSED, scores={"faithfulness": 0.9}),
+            _make_result(
+                id="t2",
+                name="failed-one",
+                status=EvalStatus.FAILED,
+                scores={"faithfulness": 0.2},
+            ),
+        ]
+        create_annotations(results, threshold=0.7)
+        out = capsys.readouterr().out  # type: ignore[union-attr]
+        lines = [ln for ln in out.strip().splitlines() if "::error::" in ln]
+        assert len(lines) == 1
+        assert "failed-one" in lines[0]
+
+
+# ---------------------------------------------------------------------------
+# format_summary_markdown
+# ---------------------------------------------------------------------------
+
+
+class TestFormatSummaryMarkdown:
+    """Test format_summary_markdown() output."""
+
+    def test_includes_header(self) -> None:
+        """Summary includes the RagaliQ header."""
+        md = format_summary_markdown([_make_result()])
+        assert "## RagaliQ Evaluation Results" in md
+
+    def test_includes_pass_count(self) -> None:
+        """Summary includes pass/total count."""
+        results = [
+            _make_result(id="t1", status=EvalStatus.PASSED),
+            _make_result(id="t2", status=EvalStatus.FAILED, scores={"faithfulness": 0.3}),
+        ]
+        md = format_summary_markdown(results)
+        assert "1/2" in md
+
+    def test_includes_threshold(self) -> None:
+        """Summary includes the configured threshold."""
+        md = format_summary_markdown([_make_result()], threshold=0.85)
+        assert "0.85" in md
+
+    def test_includes_table_header(self) -> None:
+        """Summary includes a Markdown table with evaluator columns."""
+        md = format_summary_markdown([_make_result(scores={"faithfulness": 0.9})])
+        assert "| Test Case |" in md
+        assert "faithfulness" in md
+
+    def test_includes_test_case_name_in_table(self) -> None:
+        """Table rows include the test case name."""
+        md = format_summary_markdown([_make_result(name="My test")])
+        assert "My test" in md
+
+    def test_empty_results(self) -> None:
+        """Empty results produce a header-only summary."""
+        md = format_summary_markdown([])
+        assert "0/0" in md
+        assert "| Test Case |" not in md
+
+
+# ---------------------------------------------------------------------------
+# emit_ci_summary (integration of sub-helpers)
+# ---------------------------------------------------------------------------
+
+
+class TestEmitCISummary:
+    """Test emit_ci_summary() high-level helper."""
+
+    def test_writes_summary_and_outputs(self) -> None:
+        """Writes step summary + GITHUB_OUTPUT values."""
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".md", delete=False) as sf:
+            summary_path = sf.name
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as of:
+            output_path = of.name
+        try:
+            env = {
+                "GITHUB_STEP_SUMMARY": summary_path,
+                "GITHUB_OUTPUT": output_path,
+            }
+            with patch.dict(os.environ, env):
+                results = [
+                    _make_result(id="t1", status=EvalStatus.PASSED, scores={"faithfulness": 0.9}),
+                    _make_result(
+                        id="t2",
+                        status=EvalStatus.FAILED,
+                        scores={"faithfulness": 0.3},
+                    ),
+                ]
+                emit_ci_summary(results, threshold=0.7)
+
+            summary = Path(summary_path).read_text(encoding="utf-8")
+            assert "RagaliQ" in summary
+            assert "1/2" in summary
+
+            outputs = Path(output_path).read_text(encoding="utf-8")
+            assert "total=2" in outputs
+            assert "passed=1" in outputs
+            assert "failed=1" in outputs
+        finally:
+            os.unlink(summary_path)
+            os.unlink(output_path)
+
+    def test_noop_outside_github_actions(self) -> None:
+        """Does not raise when GITHUB_STEP_SUMMARY and GITHUB_OUTPUT are unset."""
+        with patch.dict(os.environ, {}, clear=True):
+            emit_ci_summary([_make_result()])  # should not raise


### PR DESCRIPTION
Closes #18

## Changes

- **`src/ragaliq/integrations/github_actions.py`** — New module with:
  - `is_ci()` / `is_github_actions()` — environment detection via `CI` and `GITHUB_ACTIONS` env vars
  - `set_output(name, value)` — writes to `$GITHUB_OUTPUT` for downstream step access
  - `write_step_summary(markdown)` — appends Markdown to `$GITHUB_STEP_SUMMARY` (shown in Actions UI)
  - `create_annotations(results, threshold)` — emits `::error::` workflow commands for failures
  - `format_summary_markdown(results, threshold)` — builds a Markdown results table
  - `emit_ci_summary(results, threshold)` — high-level helper combining all of the above
- **`src/ragaliq/cli/main.py`** — CLI `run` command auto-detects CI:
  - Skips Rich progress spinner (renders poorly in CI logs)
  - Calls `emit_ci_summary()` when running inside GitHub Actions
- **`src/ragaliq/integrations/__init__.py`** — Exports new public API
- **`tests/unit/test_github_actions.py`** — 28 unit tests covering all helpers
- **`examples/ci_cd_example/`** — Example GitHub Actions workflow YAML + README

## Acceptance Criteria

- [x] CI detection works (`is_ci()`, `is_github_actions()`)
- [x] Step summary written (`write_step_summary()` + `emit_ci_summary()`)
- [x] Annotations for failures (`create_annotations()` emits `::error::` workflow commands)
- [x] Rich disabled in CI (no spinner, `no_color=True` Console)
- [x] Example workflow valid YAML (`examples/ci_cd_example/ragaliq-ci.yml`)
- [x] Tests pass (591 passed, 1 skipped)

## Quality Gates

- lint: `All checks passed!`
- typecheck: `Success: no issues found in 34 source files`
- test: `591 passed, 1 skipped`