### PR TITLE
[FIX #54] Pre-publish blockers: OpenAI stub, context_recall UX, sync API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@
 
 When you deploy a RAG system, how do you know the answers are accurate? How do you catch hallucinations before your users do? How do you ensure your retrieval pipeline returns the right documents?
 
-Traditional keyword-matching approaches miss semantic errors. RagaliQ solves this with **LLM-as-Judge evaluation**: Claude (or OpenAI) assesses response quality with deep semantic understanding, scoring each response across multiple evaluation metrics. This is the same approach used in academic LLM benchmarking — now available as a developer-friendly testing framework.
+Traditional keyword-matching approaches miss semantic errors. RagaliQ solves this with **LLM-as-Judge evaluation**: Claude assesses response quality with deep semantic understanding, scoring each response across multiple evaluation metrics. This is the same approach used in academic LLM benchmarking — now available as a developer-friendly testing framework.
+
+> **v0.1.0:** Claude is the supported judge. OpenAI judge support is planned — track it at [GitHub Issues](https://github.com/dariero/RagaliQ/issues).
 
 ---
 
@@ -68,6 +70,8 @@ print(f"Faithfulness: {result.scores['faithfulness']:.2f}")
 print(f"Relevance:    {result.scores['relevance']:.2f}")
 print(f"Status:       {'PASSED' if result.passed else 'FAILED'}")
 ```
+
+> **Sync vs async:** `evaluate()` and `evaluate_batch()` use `asyncio.run()` internally — they work great in scripts and CLI tools, but **cannot be called from inside a running event loop** (FastAPI handlers, Jupyter notebooks, async test functions). Use `evaluate_async()` / `evaluate_batch_async()` in those contexts.
 
 ### Pytest Integration
 

--- a/src/ragaliq/core/runner.py
+++ b/src/ragaliq/core/runner.py
@@ -98,7 +98,11 @@ class RagaliQ:
                     max_concurrency=self.max_judge_concurrency,
                 )
             case "openai":
-                raise NotImplementedError("OpenAI judge not yet implemented")
+                raise NotImplementedError(
+                    "The OpenAI judge is not yet available in v0.1.0. "
+                    "Use judge='claude' with an ANTHROPIC_API_KEY instead. "
+                    "Track OpenAI support at: https://github.com/dariero/RagaliQ/issues"
+                )
             case _:
                 raise ValueError(f"Unknown judge type: {self.judge_type}")
 
@@ -227,6 +231,12 @@ class RagaliQ:
 
         Returns:
             RAGTestResult with all metric scores.
+
+        Note:
+            This method calls asyncio.run() internally and cannot be used from
+            within a running event loop (e.g. FastAPI route handlers, Jupyter
+            notebooks, or async test functions). Use evaluate_async() instead
+            in those contexts.
         """
         import asyncio
 
@@ -285,6 +295,11 @@ class RagaliQ:
 
         Returns:
             List of RAGTestResults in the same order.
+
+        Note:
+            This method calls asyncio.run() internally and cannot be used from
+            within a running event loop. Use evaluate_batch_async() instead
+            in async contexts (FastAPI, Jupyter, async test functions).
         """
         import asyncio
 

--- a/src/ragaliq/evaluators/context_recall.py
+++ b/src/ragaliq/evaluators/context_recall.py
@@ -99,8 +99,11 @@ class ContextRecallEvaluator(Evaluator):
         # Step 0: Validate required field
         if test_case.expected_facts is None:
             raise ValueError(
-                "ContextRecallEvaluator requires test_case.expected_facts to be set. "
-                "Provide a list of ground-truth facts that should be in the context."
+                f"context_recall requires 'expected_facts' in test case '{test_case.id}'. "
+                "Add a list of ground-truth facts that should be present in the context, e.g.:\n"
+                "  RAGTestCase(..., expected_facts=['Paris is the capital of France'])\n"
+                "If you don't have ground-truth facts, use 'context_precision' instead — "
+                "it evaluates retrieval quality without requiring expected answers."
             )
 
         # Handle empty facts list: vacuously complete

--- a/src/ragaliq/integrations/pytest_plugin.py
+++ b/src/ragaliq/integrations/pytest_plugin.py
@@ -192,7 +192,11 @@ def ragaliq_judge(request: Any, ragaliq_trace_collector: TraceCollector) -> LLMJ
 
             return judge
         case "openai":
-            raise NotImplementedError("OpenAI judge not yet implemented")
+            raise NotImplementedError(
+                "The OpenAI judge is not yet available in v0.1.0. "
+                "Use --ragaliq-judge claude with an ANTHROPIC_API_KEY instead. "
+                "Track OpenAI support at: https://github.com/dariero/RagaliQ/issues"
+            )
         case _:
             raise ValueError(f"Unknown judge type: {judge_type}")
 

--- a/tests/unit/test_context_recall_evaluator.py
+++ b/tests/unit/test_context_recall_evaluator.py
@@ -194,7 +194,7 @@ class TestContextRecallAcceptanceCriteria:
         """AC: ValueError when expected_facts missing."""
         evaluator = ContextRecallEvaluator()
 
-        with pytest.raises(ValueError, match="requires test_case.expected_facts"):
+        with pytest.raises(ValueError, match="context_recall requires 'expected_facts'"):
             await evaluator.evaluate(no_expected_facts_test_case, mock_judge)
 
     @pytest.mark.asyncio

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -131,7 +131,7 @@ class TestJudgeTypeHandling:
         """OpenAI judge raises NotImplementedError."""
         runner = RagaliQ(judge="openai")
 
-        with pytest.raises(NotImplementedError, match="OpenAI judge not yet implemented"):
+        with pytest.raises(NotImplementedError, match="OpenAI judge is not yet available"):
             runner._init_judge()
 
     def test_invalid_judge_type_raises(self):


### PR DESCRIPTION
Closes #54

## Summary

- **OpenAI stub messages** — `runner.py` and `pytest_plugin.py`: replaced bare `NotImplementedError("OpenAI judge not yet implemented")` with actionable messages that say what's missing, offer the working alternative (`judge='claude'`), and link to the issue tracker.
- **context_recall UX** — `context_recall.py`: improved `ValueError` message includes the test case ID, a concrete code example, and a redirect to `context_precision` for users without ground-truth facts.
- **Sync API documentation** — `runner.evaluate()` and `evaluate_batch()`: added `Note:` section documenting the `asyncio.run()` limitation and when to use `evaluate_async()` instead.
- **README corrections** — removed "Claude (or OpenAI)" claim; added v0.1.0 callout with issue tracker link; added sync vs async callout in Quick Start.

## Quality gates

- `hatch run lint` — All checks passed ✓
- `hatch run typecheck` — 34 files, no issues ✓
- `hatch run test` — 602 passed, 1 skipped ✓

## Pre-merge checklist

- No secrets or credentials ✓
- No debug code ✓
- No TODO/FIXME introduced ✓
- Tests updated to match new error messages ✓
- All quality gates passed ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)