### PR TITLE
[FIX #56] Pre-publish audit: 5 polish items from rigorous codebase audit

### DIFF
--- a/src/ragaliq/datasets/loader.py
+++ b/src/ragaliq/datasets/loader.py
@@ -149,6 +149,7 @@ class DatasetLoader:
             # Fallback to pipe-separated
             return [item.strip() for item in value.split("|") if item.strip()]
 
+        raw_facts = row.get("expected_facts", "").strip()
         return RAGTestCase(
             id=row["id"].strip(),
             name=row["name"].strip(),
@@ -156,7 +157,7 @@ class DatasetLoader:
             context=parse_list_field(row["context"]),
             response=row["response"].strip(),
             expected_answer=row.get("expected_answer", "").strip() or None,
-            expected_facts=parse_list_field(row.get("expected_facts", "")),
+            expected_facts=parse_list_field(raw_facts) if raw_facts else None,
             tags=parse_list_field(row.get("tags", "")),
         )
 

--- a/src/ragaliq/integrations/github_actions.py
+++ b/src/ragaliq/integrations/github_actions.py
@@ -125,8 +125,11 @@ def format_summary_markdown(
     if not results:
         return "\n".join(lines)
 
-    # Collect evaluator names from the first result
-    evaluator_names = sorted(results[0].scores.keys()) if results[0].scores else []
+    # Collect evaluator names across all results (handles error envelopes with empty scores)
+    all_keys: set[str] = set()
+    for r in results:
+        all_keys.update(r.scores.keys())
+    evaluator_names = sorted(all_keys)
 
     # --- Results table ---
     header_cols = ["Test Case", "Status"] + evaluator_names

--- a/src/ragaliq/reports/console.py
+++ b/src/ragaliq/reports/console.py
@@ -74,7 +74,10 @@ class ConsoleReporter:
 
         evaluator_names: list[str] = []
         if results:
-            evaluator_names = sorted(results[0].scores.keys())
+            all_keys: set[str] = set()
+            for r in results:
+                all_keys.update(r.scores.keys())
+            evaluator_names = sorted(all_keys)
 
         for name in evaluator_names:
             table.add_column(name.replace("_", " ").title(), justify="center")
@@ -140,7 +143,10 @@ class ConsoleReporter:
 
         self._console.rule("[bold]Summary[/bold]")
 
-        evaluator_names = sorted(results[0].scores.keys())
+        all_keys: set[str] = set()
+        for r in results:
+            all_keys.update(r.scores.keys())
+        evaluator_names = sorted(all_keys)
         if evaluator_names:
             table = Table(show_header=True, show_lines=False, box=None, padding=(0, 1))
             table.add_column("Evaluator", style="bold cyan")

--- a/src/ragaliq/reports/html.py
+++ b/src/ragaliq/reports/html.py
@@ -63,7 +63,10 @@ class HTMLReporter:
         """Prepare the template context from evaluation results."""
         from ragaliq.core.test_case import EvalStatus
 
-        evaluator_names = sorted(results[0].scores.keys()) if results else []
+        all_keys: set[str] = set()
+        for r in results:
+            all_keys.update(r.scores.keys())
+        evaluator_names = sorted(all_keys)
 
         # Per-evaluator aggregate stats
         ev_rows = []

--- a/src/ragaliq/reports/json_export.py
+++ b/src/ragaliq/reports/json_export.py
@@ -63,7 +63,10 @@ class JSONReporter:
         """
         from ragaliq.core.test_case import EvalStatus
 
-        evaluator_names = sorted(results[0].scores.keys()) if results else []
+        all_keys: set[str] = set()
+        for r in results:
+            all_keys.update(r.scores.keys())
+        evaluator_names = sorted(all_keys)
 
         # Per-evaluator aggregate statistics
         ev_stats: dict[str, dict[str, Any]] = {}


### PR DESCRIPTION
Closes #56

## Changes

Fixes 5 low-severity findings from pre-publish codebase audit:

1. **`_load_documents()` informative errors** — JSON/YAML files containing wrong types (dict instead of list) now emit descriptive stderr messages instead of silently returning `[]`
2. **CSV `expected_facts` semantics** — Missing/empty `expected_facts` column now correctly produces `None` (matching `RAGTestCase` default) instead of `[]`, so `context_recall` properly detects intentional omission
3. **Reporter column robustness** — All 4 reporters (console, JSON, HTML, GitHub Actions summary) now scan all results for evaluator column names instead of only `results[0]`, handling error envelopes with empty scores dict
4. **`generate` command error handling** — `ClaudeJudge()` construction failures (missing API key) and generation errors now produce clean error messages instead of raw Python tracebacks
5. **`run` command early judge validation** — Invalid `--judge` values rejected at CLI parse time with clear error, not deferred to evaluation time

Finding #6 (sync wrapper untested) was already covered by existing tests.

## Quality Gates
- ✅ `hatch run lint` — All checks passed
- ✅ `hatch run typecheck` — no issues found in 34 source files
- ✅ `hatch run test` — 602 passed, 1 skipped

## Commits
cfaaa3a [FIX #56] Pre-publish audit polish: error messages, CSV semantics, reporter robustness