### PR TITLE
[FIX #58] Harden RAG evaluation edge cases — input validation, empty-input guards, token awareness

### DIFF
--- a/src/ragaliq/core/test_case.py
+++ b/src/ragaliq/core/test_case.py
@@ -3,7 +3,7 @@
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 
 class EvalStatus(StrEnum):
@@ -32,9 +32,18 @@ class RAGTestCase(BaseModel):
 
     id: str = Field(..., description="Unique identifier for the test case")
     name: str = Field(..., description="Human-readable name")
-    query: str = Field(..., description="The user question or input")
+    query: str = Field(..., min_length=1, description="The user question or input")
     context: list[str] = Field(..., description="Retrieved documents/chunks")
-    response: str = Field(..., description="LLM response to evaluate")
+    response: str = Field(..., min_length=1, description="LLM response to evaluate")
+
+    @field_validator("query", "response", mode="before")
+    @classmethod
+    def _strip_whitespace(cls, v: str) -> str:
+        """Strip whitespace so whitespace-only strings fail min_length."""
+        if isinstance(v, str):
+            return v.strip()
+        return v
+
     expected_answer: str | None = Field(default=None, description="Ground truth answer")
     expected_facts: list[str] | None = Field(
         default=None, description="Facts that should be present"

--- a/src/ragaliq/evaluators/context_precision.py
+++ b/src/ragaliq/evaluators/context_precision.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
     from ragaliq.core.test_case import RAGTestCase
     from ragaliq.judges.base import LLMJudge
 
+_DOC_PREVIEW_LENGTH = 200
+
 
 @register_evaluator("context_precision")
 class ContextPrecisionEvaluator(Evaluator):
@@ -122,7 +124,7 @@ class ContextPrecisionEvaluator(Evaluator):
             doc_scores.append(
                 {
                     "rank": rank,
-                    "document": test_case.context[i][:200],  # Truncate for metadata readability
+                    "document": test_case.context[i][:_DOC_PREVIEW_LENGTH],
                     "score": result.score,
                     "reasoning": result.reasoning,
                 }
@@ -166,7 +168,7 @@ class ContextPrecisionEvaluator(Evaluator):
             return "No context documents to evaluate."
 
         score_pct = score * 100
-        high_relevance = sum(1 for d in doc_scores if d["score"] >= 0.7)
+        high_relevance = sum(1 for d in doc_scores if d["score"] >= self.threshold)
 
         if high_relevance == total:
             return (

--- a/src/ragaliq/integrations/pytest_plugin.py
+++ b/src/ragaliq/integrations/pytest_plugin.py
@@ -22,6 +22,8 @@ if TYPE_CHECKING:
     from ragaliq.judges.base import LLMJudge
     from ragaliq.judges.trace import TraceCollector
 
+_HIGH_COST_WARNING_THRESHOLD = 10.0
+
 
 def pytest_addoption(parser: Any) -> None:
     """
@@ -100,7 +102,7 @@ def pytest_configure(config: Any) -> None:
         from ragaliq.judges.trace import TraceCollector
 
         config._ragaliq_trace_collector = TraceCollector()
-    except (ImportError, ModuleNotFoundError):
+    except ImportError, ModuleNotFoundError:
         # ragaliq not installed - plugin entry point loaded but can't initialize
         # This is expected in non-editable installs or when running pytest --collect-only
         config._ragaliq_trace_collector = None
@@ -362,5 +364,5 @@ def pytest_terminal_summary(terminalreporter: Any, exitstatus: int, config: Any)
     terminalreporter.write_line(f"Failures: {failures}")
 
     # Warn if approaching common budget limits
-    if total_cost > 10.0:
+    if total_cost > _HIGH_COST_WARNING_THRESHOLD:
         terminalreporter.write_line(f"WARNING: High cost detected (${total_cost:.2f})", red=True)

--- a/tests/unit/test_claims_pipeline.py
+++ b/tests/unit/test_claims_pipeline.py
@@ -1,0 +1,230 @@
+"""Unit tests for the shared claim verification pipeline (_claims.py).
+
+Tests the verify_all_claims() function directly, covering:
+- Token accumulation across extraction + verification
+- claims_empty flag behavior
+- context_empty short-circuit (no LLM calls on empty context)
+- Error propagation from extract_claims vs verify_claim
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ragaliq.evaluators._claims import ClaimVerificationResult, verify_all_claims
+from ragaliq.judges.base import (
+    ClaimsResult,
+    ClaimVerdict,
+    JudgeAPIError,
+    JudgeResponseError,
+    LLMJudge,
+)
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def mock_judge() -> MagicMock:
+    """Create a mock LLM judge."""
+    judge = MagicMock(spec=LLMJudge)
+    judge.extract_claims = AsyncMock(return_value=ClaimsResult(claims=[], tokens_used=0))
+    judge.verify_claim = AsyncMock()
+    return judge
+
+
+# =============================================================================
+# Empty Context Short-Circuit (F5)
+# =============================================================================
+
+
+class TestEmptyContextShortCircuit:
+    """Tests that empty context skips all LLM calls."""
+
+    @pytest.mark.asyncio
+    async def test_empty_context_returns_context_empty_flag(self, mock_judge: MagicMock) -> None:
+        """Empty context should set context_empty=True."""
+        result = await verify_all_claims("Some response", [], mock_judge)
+
+        assert result.context_empty is True
+        assert result.claims_empty is False
+        assert result.total_tokens == 0
+
+    @pytest.mark.asyncio
+    async def test_empty_context_skips_extract_claims(self, mock_judge: MagicMock) -> None:
+        """Empty context should NOT call extract_claims (saves tokens)."""
+        await verify_all_claims("Some response", [], mock_judge)
+
+        mock_judge.extract_claims.assert_not_called()
+        mock_judge.verify_claim.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_context_returns_empty_details(self, mock_judge: MagicMock) -> None:
+        """Empty context result should have empty claim details."""
+        result = await verify_all_claims("Some response", [], mock_judge)
+
+        assert result.claim_details == []
+        assert result.verdicts == []
+
+
+# =============================================================================
+# Empty Claims Behavior
+# =============================================================================
+
+
+class TestEmptyClaimsBehavior:
+    """Tests for when extract_claims returns no claims."""
+
+    @pytest.mark.asyncio
+    async def test_empty_claims_sets_flag(self, mock_judge: MagicMock) -> None:
+        """When extract_claims returns [], claims_empty should be True."""
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=[], tokens_used=20)
+
+        result = await verify_all_claims("Short response", ["context doc"], mock_judge)
+
+        assert result.claims_empty is True
+        assert result.context_empty is False
+        assert result.total_tokens == 20
+
+    @pytest.mark.asyncio
+    async def test_empty_claims_skips_verification(self, mock_judge: MagicMock) -> None:
+        """When no claims extracted, verify_claim should NOT be called."""
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=[], tokens_used=10)
+
+        await verify_all_claims("Short response", ["context doc"], mock_judge)
+
+        mock_judge.verify_claim.assert_not_called()
+
+
+# =============================================================================
+# Token Accumulation
+# =============================================================================
+
+
+class TestTokenAccumulation:
+    """Tests that tokens are correctly tracked across extraction + verification."""
+
+    @pytest.mark.asyncio
+    async def test_tokens_sum_extraction_and_verification(self, mock_judge: MagicMock) -> None:
+        """Total tokens should include extraction + all verification calls."""
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=["Claim A", "Claim B"], tokens_used=50
+        )
+        mock_judge.verify_claim.side_effect = [
+            ClaimVerdict(verdict="SUPPORTED", evidence="Found", tokens_used=30),
+            ClaimVerdict(verdict="NOT_ENOUGH_INFO", evidence="Missing", tokens_used=25),
+        ]
+
+        result = await verify_all_claims("Response text", ["context"], mock_judge)
+
+        assert result.total_tokens == 105  # 50 + 30 + 25
+
+    @pytest.mark.asyncio
+    async def test_tokens_with_single_claim(self, mock_judge: MagicMock) -> None:
+        """Token tracking works for single claim."""
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=["Only claim"], tokens_used=40)
+        mock_judge.verify_claim.return_value = ClaimVerdict(
+            verdict="SUPPORTED", evidence="Yes", tokens_used=20
+        )
+
+        result = await verify_all_claims("Response", ["context"], mock_judge)
+
+        assert result.total_tokens == 60  # 40 + 20
+
+
+# =============================================================================
+# Claim Details
+# =============================================================================
+
+
+class TestClaimDetails:
+    """Tests for claim detail construction."""
+
+    @pytest.mark.asyncio
+    async def test_claim_details_match_verdicts(self, mock_judge: MagicMock) -> None:
+        """Each ClaimDetail should pair the claim text with its verdict."""
+        mock_judge.extract_claims.return_value = ClaimsResult(
+            claims=["Claim X", "Claim Y"], tokens_used=10
+        )
+        mock_judge.verify_claim.side_effect = [
+            ClaimVerdict(verdict="SUPPORTED", evidence="Evidence X", tokens_used=5),
+            ClaimVerdict(verdict="CONTRADICTED", evidence="Evidence Y", tokens_used=5),
+        ]
+
+        result = await verify_all_claims("Response", ["context"], mock_judge)
+
+        assert len(result.claim_details) == 2
+        assert result.claim_details[0].claim == "Claim X"
+        assert result.claim_details[0].verdict == "SUPPORTED"
+        assert result.claim_details[0].evidence == "Evidence X"
+        assert result.claim_details[1].claim == "Claim Y"
+        assert result.claim_details[1].verdict == "CONTRADICTED"
+
+    @pytest.mark.asyncio
+    async def test_verdicts_list_preserved(self, mock_judge: MagicMock) -> None:
+        """Raw ClaimVerdict objects should be available in verdicts list."""
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=["Claim Z"], tokens_used=10)
+        verdict = ClaimVerdict(verdict="SUPPORTED", evidence="Found", tokens_used=5)
+        mock_judge.verify_claim.return_value = verdict
+
+        result = await verify_all_claims("Response", ["context"], mock_judge)
+
+        assert len(result.verdicts) == 1
+        assert result.verdicts[0].verdict == "SUPPORTED"
+
+
+# =============================================================================
+# Error Propagation
+# =============================================================================
+
+
+class TestErrorPropagation:
+    """Tests that errors from judge methods propagate correctly."""
+
+    @pytest.mark.asyncio
+    async def test_extract_claims_error_propagates(self, mock_judge: MagicMock) -> None:
+        """Error in extract_claims should propagate immediately."""
+        mock_judge.extract_claims = AsyncMock(
+            side_effect=JudgeAPIError("API failure", status_code=500)
+        )
+
+        with pytest.raises(JudgeAPIError, match="API failure"):
+            await verify_all_claims("Response", ["context"], mock_judge)
+
+    @pytest.mark.asyncio
+    async def test_verify_claim_error_propagates(self, mock_judge: MagicMock) -> None:
+        """Error in verify_claim should propagate."""
+        mock_judge.extract_claims.return_value = ClaimsResult(claims=["A claim"], tokens_used=10)
+        mock_judge.verify_claim = AsyncMock(side_effect=JudgeResponseError("Parse failure"))
+
+        with pytest.raises(JudgeResponseError, match="Parse failure"):
+            await verify_all_claims("Response", ["context"], mock_judge)
+
+
+# =============================================================================
+# Result Model
+# =============================================================================
+
+
+class TestClaimVerificationResultModel:
+    """Tests for ClaimVerificationResult defaults and immutability."""
+
+    def test_default_values(self) -> None:
+        """Default result should be empty with no flags set."""
+        result = ClaimVerificationResult()
+
+        assert result.claim_details == []
+        assert result.verdicts == []
+        assert result.total_tokens == 0
+        assert result.claims_empty is False
+        assert result.context_empty is False
+
+    def test_frozen_model(self) -> None:
+        """Result should be immutable (frozen=True)."""
+        result = ClaimVerificationResult(claims_empty=True, total_tokens=50)
+
+        with pytest.raises(Exception):  # noqa: B017
+            result.claims_empty = False  # type: ignore[misc]

--- a/tests/unit/test_context_precision_evaluator.py
+++ b/tests/unit/test_context_precision_evaluator.py
@@ -495,8 +495,10 @@ class TestContextPrecisionRawResponse:
         evaluator = ContextPrecisionEvaluator()
         result = await evaluator.evaluate(test_case, mock_judge)
 
+        from ragaliq.evaluators.context_precision import _DOC_PREVIEW_LENGTH
+
         stored_doc = result.raw_response["doc_scores"][0]["document"]
-        assert len(stored_doc) <= 200
+        assert len(stored_doc) <= _DOC_PREVIEW_LENGTH
 
 
 # =============================================================================

--- a/tests/unit/test_empty_input_edge_cases.py
+++ b/tests/unit/test_empty_input_edge_cases.py
@@ -1,0 +1,288 @@
+"""Edge case tests for empty/degenerate inputs across all evaluators.
+
+Tests that evaluators handle these degenerate cases gracefully:
+- RAGTestCase rejects empty query/response (validation)
+- Evaluators handle empty context (no unnecessary LLM calls)
+- Context recall with empty context
+- BaseJudge.evaluate_relevance empty-input guard
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from ragaliq.core.test_case import RAGTestCase
+from ragaliq.evaluators.context_recall import ContextRecallEvaluator
+from ragaliq.evaluators.faithfulness import FaithfulnessEvaluator
+from ragaliq.evaluators.hallucination import HallucinationEvaluator
+from ragaliq.judges.base import (
+    ClaimVerdict,
+    LLMJudge,
+)
+
+# =============================================================================
+# RAGTestCase Validation (F4)
+# =============================================================================
+
+
+class TestRAGTestCaseValidation:
+    """Tests that RAGTestCase rejects empty query/response."""
+
+    def test_empty_query_rejected(self) -> None:
+        """Empty string query should fail validation."""
+        with pytest.raises(ValidationError, match="query"):
+            RAGTestCase(
+                id="test",
+                name="test",
+                query="",
+                context=["doc"],
+                response="some response",
+            )
+
+    def test_whitespace_only_query_rejected(self) -> None:
+        """Whitespace-only query should fail validation after stripping."""
+        with pytest.raises(ValidationError, match="query"):
+            RAGTestCase(
+                id="test",
+                name="test",
+                query="   \t\n  ",
+                context=["doc"],
+                response="some response",
+            )
+
+    def test_empty_response_rejected(self) -> None:
+        """Empty string response should fail validation."""
+        with pytest.raises(ValidationError, match="response"):
+            RAGTestCase(
+                id="test",
+                name="test",
+                query="What is X?",
+                context=["doc"],
+                response="",
+            )
+
+    def test_whitespace_only_response_rejected(self) -> None:
+        """Whitespace-only response should fail validation after stripping."""
+        with pytest.raises(ValidationError, match="response"):
+            RAGTestCase(
+                id="test",
+                name="test",
+                query="What is X?",
+                context=["doc"],
+                response="  \n  ",
+            )
+
+    def test_valid_inputs_accepted(self) -> None:
+        """Normal non-empty inputs should pass validation."""
+        tc = RAGTestCase(
+            id="test",
+            name="test",
+            query="What is X?",
+            context=["doc"],
+            response="X is Y.",
+        )
+        assert tc.query == "What is X?"
+        assert tc.response == "X is Y."
+
+    def test_query_and_response_are_stripped(self) -> None:
+        """Leading/trailing whitespace should be stripped."""
+        tc = RAGTestCase(
+            id="test",
+            name="test",
+            query="  What is X?  ",
+            context=["doc"],
+            response="  X is Y.  ",
+        )
+        assert tc.query == "What is X?"
+        assert tc.response == "X is Y."
+
+    def test_empty_context_list_allowed(self) -> None:
+        """Empty context list should still be allowed (evaluators handle it)."""
+        tc = RAGTestCase(
+            id="test",
+            name="test",
+            query="What is X?",
+            context=[],
+            response="X is Y.",
+        )
+        assert tc.context == []
+
+
+# =============================================================================
+# Faithfulness with Empty Context (F5)
+# =============================================================================
+
+
+class TestFaithfulnessEmptyContext:
+    """Tests that faithfulness handles empty context correctly."""
+
+    @pytest.mark.asyncio
+    async def test_empty_context_returns_0_score(self) -> None:
+        """Empty context should return 0.0 (cannot assess faithfulness)."""
+        judge = MagicMock(spec=LLMJudge)
+        tc = RAGTestCase(id="test", name="test", query="Q?", context=[], response="Answer.")
+
+        evaluator = FaithfulnessEvaluator()
+        result = await evaluator.evaluate(tc, judge)
+
+        assert result.score == 0.0
+        assert result.passed is False
+        assert "context" in result.reasoning.lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_context_no_llm_calls(self) -> None:
+        """Empty context should not trigger any LLM calls."""
+        judge = MagicMock(spec=LLMJudge)
+        judge.extract_claims = AsyncMock()
+        judge.verify_claim = AsyncMock()
+        tc = RAGTestCase(id="test", name="test", query="Q?", context=[], response="Answer.")
+
+        evaluator = FaithfulnessEvaluator()
+        await evaluator.evaluate(tc, judge)
+
+        judge.extract_claims.assert_not_called()
+        judge.verify_claim.assert_not_called()
+
+
+# =============================================================================
+# Hallucination with Empty Context (F5)
+# =============================================================================
+
+
+class TestHallucinationEmptyContext:
+    """Tests that hallucination handles empty context correctly."""
+
+    @pytest.mark.asyncio
+    async def test_empty_context_returns_0_score(self) -> None:
+        """Empty context should return 0.0 (cannot assess hallucination)."""
+        judge = MagicMock(spec=LLMJudge)
+        tc = RAGTestCase(id="test", name="test", query="Q?", context=[], response="Answer.")
+
+        evaluator = HallucinationEvaluator()
+        result = await evaluator.evaluate(tc, judge)
+
+        assert result.score == 0.0
+        assert result.passed is False
+        assert "context" in result.reasoning.lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_context_no_llm_calls(self) -> None:
+        """Empty context should not trigger any LLM calls."""
+        judge = MagicMock(spec=LLMJudge)
+        judge.extract_claims = AsyncMock()
+        judge.verify_claim = AsyncMock()
+        tc = RAGTestCase(id="test", name="test", query="Q?", context=[], response="Answer.")
+
+        evaluator = HallucinationEvaluator()
+        await evaluator.evaluate(tc, judge)
+
+        judge.extract_claims.assert_not_called()
+        judge.verify_claim.assert_not_called()
+
+
+# =============================================================================
+# Context Recall with Empty Context (F13)
+# =============================================================================
+
+
+class TestContextRecallEmptyContext:
+    """Tests that context_recall handles empty context."""
+
+    @pytest.mark.asyncio
+    async def test_empty_context_with_facts_returns_0(self) -> None:
+        """Empty context with expected facts should return 0.0 (all NOT_ENOUGH_INFO)."""
+        judge = MagicMock(spec=LLMJudge)
+        judge.verify_claim = AsyncMock(
+            return_value=ClaimVerdict(
+                verdict="NOT_ENOUGH_INFO",
+                evidence="No context provided for verification.",
+                tokens_used=0,
+            )
+        )
+        tc = RAGTestCase(
+            id="test",
+            name="test",
+            query="Q?",
+            context=[],
+            response="Answer.",
+            expected_facts=["Fact A", "Fact B"],
+        )
+
+        evaluator = ContextRecallEvaluator()
+        result = await evaluator.evaluate(tc, judge)
+
+        assert result.score == 0.0
+        assert result.passed is False
+
+
+# =============================================================================
+# BaseJudge.evaluate_relevance Empty Input Guard (F2)
+# =============================================================================
+
+
+class TestEvaluateRelevanceEmptyGuard:
+    """Tests that evaluate_relevance guards against empty inputs."""
+
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_0(self) -> None:
+        """Empty query in evaluate_relevance should return 0.0 immediately."""
+        from ragaliq.judges.base_judge import BaseJudge
+
+        transport = MagicMock()
+        judge = BaseJudge.__new__(BaseJudge)
+        judge.config = MagicMock()
+        judge._transport = transport
+        judge._trace_collector = None
+
+        import asyncio
+
+        judge._concurrency_limit = asyncio.Semaphore(20)
+
+        result = await judge.evaluate_relevance(query="", response="Some response")
+
+        assert result.score == 0.0
+        assert result.tokens_used == 0
+        assert "empty" in result.reasoning.lower()
+
+    @pytest.mark.asyncio
+    async def test_empty_response_returns_0(self) -> None:
+        """Empty response in evaluate_relevance should return 0.0 immediately."""
+        from ragaliq.judges.base_judge import BaseJudge
+
+        transport = MagicMock()
+        judge = BaseJudge.__new__(BaseJudge)
+        judge.config = MagicMock()
+        judge._transport = transport
+        judge._trace_collector = None
+
+        import asyncio
+
+        judge._concurrency_limit = asyncio.Semaphore(20)
+
+        result = await judge.evaluate_relevance(query="What is X?", response="")
+
+        assert result.score == 0.0
+        assert result.tokens_used == 0
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_treated_as_empty(self) -> None:
+        """Whitespace-only query/response should trigger the empty guard."""
+        from ragaliq.judges.base_judge import BaseJudge
+
+        transport = MagicMock()
+        judge = BaseJudge.__new__(BaseJudge)
+        judge.config = MagicMock()
+        judge._transport = transport
+        judge._trace_collector = None
+
+        import asyncio
+
+        judge._concurrency_limit = asyncio.Semaphore(20)
+
+        result = await judge.evaluate_relevance(query="  \n  ", response="Answer")
+
+        assert result.score == 0.0
+        assert result.tokens_used == 0

--- a/tests/unit/test_faithfulness_evaluator.py
+++ b/tests/unit/test_faithfulness_evaluator.py
@@ -3,7 +3,7 @@
 Tests follow the acceptance criteria from Issue #6:
 - All claims supported -> 1.0
 - Half supported -> 0.5
-- No claims -> 1.0 (vacuously faithful)
+- No claims -> 0.0 (cannot assess faithfulness)
 - All unsupported -> 0.0
 """
 
@@ -174,13 +174,13 @@ class TestFaithfulnessEvaluatorAcceptanceCriteria:
         assert result.tokens_used == 75  # 40 + 20 + 15
 
     @pytest.mark.asyncio
-    async def test_no_claims_returns_1_0(
+    async def test_no_claims_returns_0_0(
         self,
         mock_judge: MagicMock,
         faithful_test_case: RAGTestCase,
     ) -> None:
-        """AC: No claims -> 1.0 (vacuously faithful)"""
-        # Arrange: empty response extracts no claims
+        """AC: No claims -> 0.0 (cannot assess faithfulness)"""
+        # Arrange: response extracts no claims
         mock_judge.extract_claims.return_value = ClaimsResult(claims=[], tokens_used=15)
 
         # Act
@@ -188,8 +188,8 @@ class TestFaithfulnessEvaluatorAcceptanceCriteria:
         result = await evaluator.evaluate(faithful_test_case, mock_judge)
 
         # Assert
-        assert result.score == 1.0
-        assert result.passed is True
+        assert result.score == 0.0
+        assert result.passed is False
         assert result.tokens_used == 15  # Only extraction tokens
         # verify_claim should never be called with no claims
         mock_judge.verify_claim.assert_not_called()

--- a/tests/unit/test_hallucination_evaluator.py
+++ b/tests/unit/test_hallucination_evaluator.py
@@ -364,12 +364,14 @@ class TestHallucinationEvaluatorMetadata:
         mock_judge: MagicMock,
         grounded_test_case: RAGTestCase,
     ) -> None:
-        """Empty claims should produce clean metadata."""
+        """Empty claims should produce clean metadata with score 0.0."""
         mock_judge.extract_claims.return_value = ClaimsResult(claims=[])
 
         evaluator = HallucinationEvaluator()
         result = await evaluator.evaluate(grounded_test_case, mock_judge)
 
+        assert result.score == 0.0
+        assert result.passed is False
         assert result.raw_response["total_claims"] == 0
         assert result.raw_response["hallucination_count"] == 0
         assert result.raw_response["hallucinated_claims"] == []
@@ -457,19 +459,19 @@ class TestHallucinationEvaluatorEdgeCases:
     """Tests for edge cases and boundary conditions."""
 
     @pytest.mark.asyncio
-    async def test_no_claims_returns_1_0(
+    async def test_no_claims_returns_0_0(
         self,
         mock_judge: MagicMock,
         grounded_test_case: RAGTestCase,
     ) -> None:
-        """No claims extracted should give score 1.0 (no hallucinations)."""
+        """No claims extracted should give score 0.0 (cannot assess)."""
         mock_judge.extract_claims.return_value = ClaimsResult(claims=[])
 
         evaluator = HallucinationEvaluator()
         result = await evaluator.evaluate(grounded_test_case, mock_judge)
 
-        assert result.score == 1.0
-        assert result.passed is True
+        assert result.score == 0.0
+        assert result.passed is False
         mock_judge.verify_claim.assert_not_called()
 
     @pytest.mark.asyncio


### PR DESCRIPTION
Closes #58

## Summary

Addresses all findings from the pre-playground readiness audit. Fixes degenerate-input behavior, unnecessary LLM calls, and replaces magic numbers with named constants.

## Changes

- **F4** `RAGTestCase`: `min_length=1` + `_strip_whitespace` validator on `query`/`response` — rejects empty and whitespace-only strings at the model level
- **F2** `BaseJudge.evaluate_relevance()`: early return with score=0.0 when query or response is empty/whitespace
- **F5** `_claims.py`: short-circuit on empty context (skip `extract_claims` LLM call), new `context_empty` flag on `ClaimVerificationResult`
- **F6** `BaseJudge._call_llm()`: logs a warning when estimated input tokens exceed `_DEFAULT_INPUT_TOKEN_WARN_THRESHOLD` (100k tokens)
- **F8** `FaithfulnessEvaluator` / `HallucinationEvaluator`: empty claims and empty context now return score=0.0 (previously 1.0 via vacuous truth) — fail closed, not open
- **F9** `ContextPrecisionEvaluator._build_reasoning()`: replaced hardcoded `0.7` with `self.threshold`
- **F15** Named constants for all remaining magic numbers: `_DOC_PREVIEW_LENGTH`, `_ERROR_PREVIEW_LENGTH`, `_HIGH_COST_WARNING_THRESHOLD`
- **F10/F11** New test files: `test_claims_pipeline.py` (direct unit tests for `_claims.py`) and `test_empty_input_edge_cases.py` (empty-input edge cases across all evaluators)
- Updated existing vacuous-truth tests in faithfulness/hallucination suites to reflect new 0.0 semantics

## Test plan

- [x] `hatch run lint` — All checks passed
- [x] `hatch run typecheck` — No issues found in 34 source files
- [x] `hatch run test` — 630 passed, 1 skipped, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)