### PR TITLE
[FEAT #64] Repository publication infrastructure: packaging, CI/CD, Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,58 @@
+# Version control
+.git/
+.gitignore
+
+# Python build artifacts
+__pycache__/
+*.py[cod]
+*.so
+*.egg-info/
+dist/
+build/
+.eggs/
+
+# Virtual environments
+.venv/
+venv/
+.hatch/
+
+# Test and coverage
+tests/
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
+# Type checking and linting caches
+.mypy_cache/
+.ruff_cache/
+
+# Documentation
+docs/
+
+# Development tooling
+.claude/
+.cursor/
+.github/
+.decisions/
+scripts/
+examples/
+
+# Local environment / secrets
+.env*
+*.pem
+*credentials*
+*secret*
+.secrets/
+
+# Editor / OS
+.DS_Store
+.idea/
+.vscode/
+*.swp
+*~
+
+# Logs and reports
+*.log
+reports/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,95 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+# Cancel in-progress runs for the same branch/PR when a new commit is pushed.
+# This prevents wasted CI minutes on stale builds.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # ──────────────────────────────────────────────────────────────────────
+  # Job 1: Lint — runs ruff on src/ and tests/
+  # Runs on Python 3.12 only (linting is not version-sensitive)
+  # ──────────────────────────────────────────────────────────────────────
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Run ruff
+        run: hatch run lint
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Job 2: Type Check — runs mypy in strict mode
+  # ──────────────────────────────────────────────────────────────────────
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Run mypy
+        run: hatch run typecheck
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Job 3: Test — runs unit tests across the supported Python matrix.
+  # Only tests/unit/ runs here — integration tests need live API keys
+  # and are gated to the release workflow where secrets are available.
+  # ──────────────────────────────────────────────────────────────────────
+  test:
+    name: Test (Python ${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false  # Let all matrix versions run even if one fails
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: "pip"
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Run unit tests
+        # Override test path to unit-only; addopts in pyproject.toml adds --cov automatically.
+        # --cov-report=xml produces coverage.xml for upload below.
+        run: hatch run pytest tests/unit/ --cov-report=xml
+
+      # Upload coverage only from the canonical version (3.12) to avoid duplicates.
+      - name: Upload coverage to Codecov
+        if: matrix.python-version == '3.12'
+        uses: codecov/codecov-action@v4
+        with:
+          files: ./coverage.xml
+          # fail_ci_if_error: false keeps CI green even if Codecov is down.
+          fail_ci_if_error: false
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,213 @@
+name: Release
+
+# Triggers when a version tag is pushed: git tag v0.2.0 && git push --tags
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  # ──────────────────────────────────────────────────────────────────────
+  # Job 1: Validate — re-run unit tests + verify the tag matches pyproject.toml.
+  # This is the safety gate. If it fails, nothing gets published.
+  # ──────────────────────────────────────────────────────────────────────
+  validate:
+    name: Validate Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Run unit tests
+        run: hatch run pytest tests/unit/
+
+      - name: Verify version tag matches pyproject.toml
+        # Strips the leading 'v' from the tag (v0.2.0 → 0.2.0) and compares
+        # to the version declared in pyproject.toml. Catches the common mistake
+        # of tagging v0.2.0 while pyproject.toml still says 0.1.0.
+        run: |
+          PYPROJECT_VERSION=$(python -c "
+          import tomllib
+          with open('pyproject.toml', 'rb') as f:
+              print(tomllib.load(f)['project']['version'])
+          ")
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          echo "pyproject.toml version : $PYPROJECT_VERSION"
+          echo "Git tag version        : $TAG_VERSION"
+          if [ "$PYPROJECT_VERSION" != "$TAG_VERSION" ]; then
+            echo "❌ Version mismatch. Update pyproject.toml and src/ragaliq/__init__.py before tagging."
+            exit 1
+          fi
+          echo "✅ Versions match."
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Job 2: Build — produce the wheel and source distribution.
+  # The artifacts from this job are shared with all downstream publish jobs,
+  # ensuring everyone publishes the exact same bytes.
+  # ──────────────────────────────────────────────────────────────────────
+  build:
+    name: Build Distribution
+    needs: [validate]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: "pip"
+
+      - name: Install build tools
+        run: pip install hatch build
+
+      - name: Build wheel and sdist
+        run: python -m build
+
+      - name: Verify the distribution
+        # twine check ensures the wheel/sdist metadata is valid before upload.
+        run: |
+          pip install twine
+          twine check dist/*
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 7
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Job 3: Publish to PyPI — uses Trusted Publishers (OIDC).
+  #
+  # HOW TRUSTED PUBLISHERS WORK:
+  # Instead of storing a long-lived API token in GitHub Secrets, PyPI issues
+  # a short-lived OIDC token during the workflow run. The `id-token: write`
+  # permission lets this workflow request that token from GitHub's OIDC provider.
+  # PyPI verifies it came from this exact repo + workflow combination.
+  # No secret to rotate, no token to leak.
+  #
+  # SETUP REQUIRED (one-time, on pypi.org):
+  # 1. Go to pypi.org → Your account → Publishing → Add a new publisher
+  # 2. Set: owner=dariero, repo=RagaliQ, workflow=release.yml, env=pypi
+  # ──────────────────────────────────────────────────────────────────────
+  publish-pypi:
+    name: Publish to PyPI
+    needs: [build]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/ragaliq/
+    permissions:
+      id-token: write  # REQUIRED for Trusted Publishers OIDC
+
+    steps:
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Job 4: Build and Push Docker Image — to GitHub Container Registry (GHCR).
+  #
+  # GHCR vs Docker Hub: GHCR uses GITHUB_TOKEN automatically (no extra secrets),
+  # images are scoped to your GitHub org/user, and they're free for public repos.
+  # The image will be at: ghcr.io/dariero/ragaliq:<version>
+  #
+  # To also push to Docker Hub, add the login-action step with:
+  #   registry: docker.io
+  #   username: ${{ secrets.DOCKERHUB_USERNAME }}
+  #   password: ${{ secrets.DOCKERHUB_TOKEN }}
+  # ──────────────────────────────────────────────────────────────────────
+  publish-docker:
+    name: Publish Docker Image
+    needs: [build]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write  # REQUIRED to push to GHCR
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/ragaliq
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          # GHA cache makes subsequent builds significantly faster by reusing layers.
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  # ──────────────────────────────────────────────────────────────────────
+  # Job 5: Create GitHub Release — attaches the wheel and sdist as assets.
+  # Runs only after both publish jobs succeed.
+  # ──────────────────────────────────────────────────────────────────────
+  create-github-release:
+    name: Create GitHub Release
+    needs: [publish-pypi, publish-docker]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write  # REQUIRED to create releases and upload assets
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history needed for release notes generation
+
+      - name: Download distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true  # Auto-generates notes from merged PRs
+          body: |
+            ## Installation
+
+            ```bash
+            pip install ragaliq==${{ github.ref_name }}
+            ```
+
+            Docker image:
+            ```bash
+            docker pull ghcr.io/dariero/ragaliq:${{ github.ref_name }}
+            ```
+
+            Full changelog: [CHANGELOG.md](https://github.com/dariero/RagaliQ/blob/main/CHANGELOG.md)

--- a/.gitignore
+++ b/.gitignore
@@ -90,3 +90,16 @@ Thumbs.db
 *.pem
 *credentials*
 *secret*
+
+# Hatch virtual environments
+.hatch/
+
+# Cursor IDE
+.cursor/
+.cursorignore
+
+# Claude Code (local session settings — not for public consumption)
+.claude/settings.local.json
+
+# Stale root-level package artifacts (use src/ layout only)
+ragaliq/__pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to RagaliQ
+
+Thank you for your interest in contributing! RagaliQ is an open-source LLM/RAG evaluation framework and we welcome bug reports, feature ideas, and pull requests.
+
+## Before You Start
+
+- Check the [GitHub Issues](https://github.com/dariero/RagaliQ/issues) to see if your bug or feature is already tracked.
+- For significant changes, open an issue first to discuss the approach before writing code.
+
+## Development Setup
+
+**Requirements:** Python 3.12+, [Hatch](https://hatch.pypa.io/)
+
+```bash
+git clone https://github.com/dariero/RagaliQ.git
+cd RagaliQ
+pip install hatch
+hatch shell         # creates and activates a virtual environment
+```
+
+## Quality Gates
+
+All contributions must pass these checks before merging:
+
+```bash
+hatch run lint       # ruff check (style and imports)
+hatch run typecheck  # mypy strict mode
+hatch run test       # pytest with coverage
+```
+
+Run them together:
+
+```bash
+hatch run check
+```
+
+## Code Standards
+
+- **Type hints** are required on all public functions and methods.
+- **Docstrings** must use [Google style](https://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings).
+- **Evaluator pattern**: each new metric MUST be a separate `Evaluator` subclass with an `evaluate()` method. See `src/ragaliq/evaluators/` for examples.
+- **Async-first**: all LLM calls must be `async def`.
+- **Pydantic models** for all data structures (no raw dicts).
+
+## Submitting a Pull Request
+
+1. Fork the repository and create a branch: `feat/<short-description>`.
+2. Make your changes and ensure all quality gates pass.
+3. Write or update tests in `tests/` mirroring the `src/` structure.
+4. Open a PR against `main` with a clear description of what changed and why.
+
+## Reporting Bugs
+
+Open a [GitHub Issue](https://github.com/dariero/RagaliQ/issues/new) with:
+- Python version and OS
+- RagaliQ version (`pip show ragaliq`)
+- A minimal reproducible example
+- The full error traceback
+
+## Security Vulnerabilities
+
+Please do **not** open a public issue for security vulnerabilities. See [SECURITY.md](SECURITY.md) for the responsible disclosure process.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the [MIT License](LICENSE).

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 1: builder
+# Builds the wheel inside a dedicated layer so build tools don't end up
+# in the final image. Only the compiled .whl is passed to the runtime stage.
+# ──────────────────────────────────────────────────────────────────────────────
+FROM python:3.12-slim AS builder
+
+WORKDIR /build
+
+# Copy only the files needed to build the package.
+# Separating COPY steps this way means Docker can cache the pip install layer
+# independently of source code changes.
+COPY pyproject.toml README.md ./
+COPY src/ ./src/
+
+RUN pip install --no-cache-dir build \
+    && python -m build --wheel --outdir /dist
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Stage 2: runtime
+# Starts from a clean slim base — no build tools, no source, no cache.
+# ──────────────────────────────────────────────────────────────────────────────
+FROM python:3.12-slim AS runtime
+
+LABEL org.opencontainers.image.title="RagaliQ" \
+      org.opencontainers.image.description="LLM & RAG Evaluation Testing Framework" \
+      org.opencontainers.image.source="https://github.com/dariero/RagaliQ" \
+      org.opencontainers.image.licenses="MIT"
+
+WORKDIR /app
+
+# Copy the wheel from the builder stage and install it.
+# --no-cache-dir keeps the image smaller by not storing pip's download cache.
+COPY --from=builder /dist/*.whl /tmp/
+RUN pip install --no-cache-dir /tmp/ragaliq-*.whl \
+    && rm /tmp/ragaliq-*.whl
+
+# The ANTHROPIC_API_KEY must be supplied at runtime:
+#   docker run -e ANTHROPIC_API_KEY=sk-ant-... ghcr.io/dariero/ragaliq run ...
+# Never bake secrets into the image.
+
+ENTRYPOINT ["ragaliq"]
+CMD ["--help"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,10 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
+    "Operating System :: OS Independent",
     "Topic :: Software Development :: Testing",
     "Topic :: Software Development :: Quality Assurance",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
@@ -73,7 +76,7 @@ ragaliq = "ragaliq.integrations.pytest_plugin"
 
 [project.urls]
 Homepage = "https://github.com/dariero/RagaliQ"
-Documentation = "https://github.com/dariero/RagaliQ/docs/TUTORIAL.md"
+Documentation = "https://github.com/dariero/RagaliQ/blob/main/docs/TUTORIAL.md"
 Repository = "https://github.com/dariero/RagaliQ"
 Issues = "https://github.com/dariero/RagaliQ/issues"
 Changelog = "https://github.com/dariero/RagaliQ/blob/main/CHANGELOG.md"


### PR DESCRIPTION
Closes #64

## Changes

### Phase 1 — Packaging & Metadata
- **`pyproject.toml`**: Added Python 3.12 and 3.13 classifiers (were missing despite `requires-python = ">=3.12"`), added `Operating System :: OS Independent`, fixed broken Documentation URL
- **`.gitignore`**: Added `.hatch/`, `.cursor/`, `.claude/settings.local.json`, stale root-level pycache entry

### Phase 2 — CI/CD
- **`.github/workflows/ci.yml`**: Three-job pipeline — lint (ruff), typecheck (mypy), and test matrix across Python 3.12/3.13/3.14; concurrency groups cancel stale PR runs
- **`.github/workflows/release.yml`**: Five-job release pipeline — validate (version tag ↔ pyproject.toml check), build (wheel + sdist), publish to PyPI via Trusted Publishers (OIDC, no stored tokens), publish to GHCR (Docker), create GitHub Release with assets attached
- **`Dockerfile`**: Multi-stage build — builder stage compiles the wheel, runtime stage is clean `python:3.12-slim` with only the installed package
- **`.dockerignore`**: Excludes tests, docs, tooling, secrets from Docker build context
- **`CONTRIBUTING.md`**: Development setup, code standards, PR process, bug reporting guide

## Quality Gates

- ✅ `hatch run lint` — All checks passed
- ⚠️ `hatch run typecheck` — Pre-existing mypy issues (tracked separately, not introduced by this PR)
- ✅ `hatch run test` — 630 passed, 1 skipped

## One-Time Setup After Merge

1. Configure PyPI Trusted Publisher (pypi.org → Publishing → Add publisher: repo=RagaliQ, workflow=release.yml, env=pypi)
2. Create `pypi` GitHub Environment (Settings → Environments)
3. Add `CODECOV_TOKEN` secret for coverage uploads