### PR TITLE
[FIX #66] Replace hatch run with direct pip install in CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ concurrency:
 jobs:
   # ──────────────────────────────────────────────────────────────────────
   # Job 1: Lint — runs ruff on src/ and tests/
-  # Runs on Python 3.12 only (linting is not version-sensitive)
+  # Runs on Python 3.12 only (linting is not version-sensitive).
+  # Uses pip install directly — bypasses Hatch's virtualenv layer which
+  # is incompatible with virtualenv>=20.27 on fresh CI runners.
   # ──────────────────────────────────────────────────────────────────────
   lint:
     name: Lint
@@ -28,11 +30,11 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
-      - name: Install Hatch
-        run: pip install hatch
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
 
       - name: Run ruff
-        run: hatch run lint
+        run: ruff check src/ tests/
 
   # ──────────────────────────────────────────────────────────────────────
   # Job 2: Type Check — runs mypy in strict mode
@@ -48,11 +50,11 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
-      - name: Install Hatch
-        run: pip install hatch
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
 
       - name: Run mypy
-        run: hatch run typecheck
+        run: mypy src/
 
   # ──────────────────────────────────────────────────────────────────────
   # Job 3: Test — runs unit tests across the supported Python matrix.
@@ -75,13 +77,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
-      - name: Install Hatch
-        run: pip install hatch
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
 
       - name: Run unit tests
-        # Override test path to unit-only; addopts in pyproject.toml adds --cov automatically.
-        # --cov-report=xml produces coverage.xml for upload below.
-        run: hatch run pytest tests/unit/ --cov-report=xml
+        # addopts in pyproject.toml adds --cov=ragaliq automatically.
+        # --cov-report=xml produces coverage.xml for the Codecov upload below.
+        run: pytest tests/unit/ --cov-report=xml
 
       # Upload coverage only from the canonical version (3.12) to avoid duplicates.
       - name: Upload coverage to Codecov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,11 @@ jobs:
           python-version: "3.12"
           cache: "pip"
 
-      - name: Install Hatch
-        run: pip install hatch
+      - name: Install dev dependencies
+        run: pip install -e ".[dev]"
 
       - name: Run unit tests
-        run: hatch run pytest tests/unit/
+        run: pytest tests/unit/
 
       - name: Verify version tag matches pyproject.toml
         # Strips the leading 'v' from the tag (v0.2.0 → 0.2.0) and compares


### PR DESCRIPTION
Closes #66

## Root Cause

`virtualenv >= 20.27.0` removed `propose_interpreters` from `virtualenv.discovery.builtin`. Hatch calls this API when creating its managed environments, so `pip install hatch` on a fresh runner + every `hatch run *` command → immediate crash before any tool runs.

Works locally because existing Hatch envs were built with an older virtualenv and are already cached on disk.

## Fix

Replace `hatch run` with direct tool invocation in both workflow files:

| Before | After |
|---|---|
| `pip install hatch` | `pip install -e ".[dev]"` |
| `hatch run lint` | `ruff check src/ tests/` |
| `hatch run typecheck` | `mypy src/` |
| `hatch run pytest tests/unit/` | `pytest tests/unit/` |

The GitHub Actions runner already has the correct Python version from `actions/setup-python` — no second virtualenv is needed inside it.

## Quality Gates

- ✅ `hatch run lint` — All checks passed
- ✅ `hatch run test` — 630 passed, 1 skipped