### PR TITLE
[REFACTOR #68] Drop Python 3.12/3.13 — require Python 3.14+ globally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ concurrency:
 jobs:
   # ──────────────────────────────────────────────────────────────────────
   # Job 1: Lint — runs ruff on src/ and tests/
-  # Runs on Python 3.12 only (linting is not version-sensitive).
-  # Uses pip install directly — bypasses Hatch's virtualenv layer which
-  # is incompatible with virtualenv>=20.27 on fresh CI runners.
   # ──────────────────────────────────────────────────────────────────────
   lint:
     name: Lint
@@ -27,7 +24,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install dev dependencies
@@ -47,7 +44,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install dev dependencies
@@ -57,24 +54,19 @@ jobs:
         run: mypy src/
 
   # ──────────────────────────────────────────────────────────────────────
-  # Job 3: Test — runs unit tests across the supported Python matrix.
+  # Job 3: Test — runs unit tests on Python 3.14 (the only supported version).
   # Only tests/unit/ runs here — integration tests need live API keys
   # and are gated to the release workflow where secrets are available.
   # ──────────────────────────────────────────────────────────────────────
   test:
-    name: Test (Python ${{ matrix.python-version }})
+    name: Test (Python 3.14)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false  # Let all matrix versions run even if one fails
-      matrix:
-        python-version: ["3.12", "3.13", "3.14"]
-
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install dev dependencies
@@ -85,9 +77,7 @@ jobs:
         # --cov-report=xml produces coverage.xml for the Codecov upload below.
         run: pytest tests/unit/ --cov-report=xml
 
-      # Upload coverage only from the canonical version (3.12) to avoid duplicates.
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.12'
         uses: codecov/codecov-action@v4
         with:
           files: ./coverage.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install dev dependencies
@@ -61,7 +61,7 @@ jobs:
 
       - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: "3.14"
           cache: "pip"
 
       - name: Install build tools

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Builds the wheel inside a dedicated layer so build tools don't end up
 # in the final image. Only the compiled .whl is passed to the runtime stage.
 # ──────────────────────────────────────────────────────────────────────────────
-FROM python:3.12-slim AS builder
+FROM python:3.14-slim AS builder
 
 WORKDIR /build
 
@@ -20,7 +20,7 @@ RUN pip install --no-cache-dir build \
 # Stage 2: runtime
 # Starts from a clean slim base — no build tools, no source, no cache.
 # ──────────────────────────────────────────────────────────────────────────────
-FROM python:3.12-slim AS runtime
+FROM python:3.14-slim AS runtime
 
 LABEL org.opencontainers.image.title="RagaliQ" \
       org.opencontainers.image.description="LLM & RAG Evaluation Testing Framework" \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.1.0"
 description = "LLM & RAG evaluation testing framework — hallucination detection, faithfulness metrics, answer relevance scoring, and retrieval pipeline testing with pytest integration"
 readme = "README.md"
 license = "MIT"
-requires-python = ">=3.12"
+requires-python = ">=3.14"
 authors = [
     { name = "Darie Ro" }
 ]
@@ -35,8 +35,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Testing",
@@ -117,7 +115,7 @@ clean = [
 ]
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py314"
 line-length = 100
 src = ["src", "tests"]
 
@@ -142,7 +140,7 @@ ignore = [
 known-first-party = ["ragaliq"]
 
 [tool.mypy]
-python_version = "3.12"
+python_version = "3.14"
 strict = true
 warn_return_any = true
 warn_unused_configs = true


### PR DESCRIPTION
Closes #68

## Changes

| File | Change |
|---|---|
| `pyproject.toml` | `requires-python >=3.14`, removed 3.12/3.13 classifiers, `ruff target-version = py314`, `mypy python_version = 3.14` |
| `ci.yml` | Removed matrix strategy entirely — single Python 3.14 job, removed conditional coverage guard |
| `release.yml` | Both validate and build jobs now use Python 3.14 |
| `Dockerfile` | Both builder and runtime stages use `python:3.14-slim` |

## Quality Gates

- ✅ `hatch run lint` — All checks passed
- ✅ `hatch run test` — 630 passed, 1 skipped