### PR TITLE
[FEAT #70] Phase 3: security policy, issue templates, PR template, code of conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,84 @@
+name: Bug Report
+description: File a bug report for RagaliQ
+title: "[BUG] "
+labels: ["bug"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. Please fill in as much detail as possible.
+        For **security vulnerabilities**, use [Report a vulnerability](https://github.com/dariero/RagaliQ/security/advisories/new) instead.
+
+  - type: input
+    id: version
+    attributes:
+      label: RagaliQ Version
+      placeholder: "e.g. 0.1.0  (run: pip show ragaliq)"
+    validations:
+      required: true
+
+  - type: input
+    id: python-version
+    attributes:
+      label: Python Version
+      placeholder: "e.g. 3.14.0  (run: python --version)"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: Operating System
+      placeholder: "e.g. macOS 15, Ubuntu 24.04, Windows 11"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: judge
+    attributes:
+      label: Judge in Use
+      options:
+        - Claude (ClaudeJudge)
+        - OpenAI (OpenAIJudge)
+        - N/A — not using a judge
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Minimal Reproduction
+      description: The smallest possible code snippet or CLI command that reproduces the issue.
+      render: python
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behaviour
+    validations:
+      required: true
+
+  - type: textarea
+    id: traceback
+    attributes:
+      label: Full Error Traceback
+      description: Paste the complete traceback here. Do not truncate it.
+      render: python

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,12 @@
+# Disabling blank issues forces contributors to use a structured template,
+# which gives maintainers the context they need to act quickly.
+blank_issues_enabled: false
+
+contact_links:
+  - name: Report a Security Vulnerability
+    url: https://github.com/dariero/RagaliQ/security/advisories/new
+    about: Please report security issues privately using GitHub's advisory system — not as a public issue.
+
+  - name: Question or Discussion
+    url: https://github.com/dariero/RagaliQ/discussions
+    about: Ask a question, share how you're using RagaliQ, or discuss ideas before filing an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,58 @@
+name: Feature Request
+description: Suggest a new evaluator, judge integration, or improvement
+title: "[FEAT] "
+labels: ["feat"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before opening a feature request, please check the [GitHub Issues](https://github.com/dariero/RagaliQ/issues)
+        to see if it has already been proposed.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of RagaliQ does this relate to?
+      options:
+        - New evaluator metric
+        - Judge integration (new LLM provider)
+        - CLI command
+        - Report format
+        - Dataset loading / generation
+        - Pytest plugin
+        - Performance / async
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: What problem does this solve? What are you unable to do today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: Describe the feature you'd like. If it's a new evaluator, describe what it measures and how.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any other approaches you considered, and why you prefer this one.
+
+  - type: checkboxes
+    id: contribution
+    attributes:
+      label: Contribution
+      options:
+        - label: I am willing to submit a pull request for this feature.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,37 @@
+## Summary
+
+<!-- What does this PR do? 1-3 sentences. -->
+
+## Type of Change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] CI/CD / infrastructure
+
+## Related Issue
+
+Closes #
+
+## Quality Gates
+
+All three must pass before merging:
+
+```bash
+hatch run lint       # ruff — style and imports
+hatch run typecheck  # mypy strict
+hatch run test       # pytest + coverage
+```
+
+- [ ] `hatch run lint` passes
+- [ ] `hatch run typecheck` passes
+- [ ] `hatch run test` passes (no regressions)
+
+## Checklist
+
+- [ ] New evaluators are a separate `Evaluator` subclass with an `evaluate()` method
+- [ ] All public functions have type hints (required) and Google-style docstrings
+- [ ] Tests added or updated in `tests/` mirroring the `src/` structure
+- [ ] `CHANGELOG.md` updated for any user-facing change
+- [ ] No secrets, API keys, `.env` content, or debug code (`print`, breakpoints) in this PR

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening a [GitHub Issue](https://github.com/dariero/RagaliQ/issues) or contacting the maintainer directly via GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security patches are applied to the latest release only.
+
+| Version | Supported |
+|---|---|
+| 0.1.x (latest) | ✅ |
+| < 0.1.0 | ❌ |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub Issues.**
+
+RagaliQ uses GitHub's private security advisory system. To report a vulnerability:
+
+1. Go to **[Security → Report a vulnerability](https://github.com/dariero/RagaliQ/security/advisories/new)**
+2. Describe the issue: what it is, steps to reproduce, and the potential impact
+3. You will receive an acknowledgment within **72 hours**
+
+We ask that you do not disclose the vulnerability publicly until a patch has been released. We will credit reporters in the release notes unless you prefer to remain anonymous.
+
+## Scope
+
+**In scope:**
+- Code injection or arbitrary code execution via the CLI or Python API
+- Insecure handling of API keys or credentials passed to evaluators
+- Prompt injection vulnerabilities in evaluator prompts that could exfiltrate data
+- Dependency vulnerabilities with a known CVE affecting RagaliQ users
+
+**Out of scope:**
+- Rate limiting or availability issues on external LLM APIs (Anthropic, OpenAI) — these are outside our control
+- Vulnerabilities in test datasets or examples provided by users
+- Social engineering
+
+## Preferred Languages
+
+Reports may be submitted in English.


### PR DESCRIPTION
Closes #70

## Changes

| File | Purpose |
|---|---|
| `SECURITY.md` | Private advisory disclosure, 72h SLA, in/out-of-scope definitions |
| `CODE_OF_CONDUCT.md` | Contributor Covenant 2.1 |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Structured YAML form — version, OS, judge, reproduction, traceback |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | Area dropdown, problem/solution/alternatives, contribution checkbox |
| `.github/ISSUE_TEMPLATE/config.yml` | Blank issues disabled; security advisory + Discussions contact links |
| `.github/PULL_REQUEST_TEMPLATE.md` | Quality gate commands, evaluator pattern reminder, no-secrets assertion |

## Quality Gates

- ✅ `hatch run lint` — All checks passed
- ✅ `hatch run test` — 630 passed, 1 skipped