### PR TITLE
[FEAT #72] Phase 4: MkDocs Material docs site and README badge wiring

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,55 @@
+name: Docs
+
+# Deploys the MkDocs site to GitHub Pages on every push to main.
+# Also triggerable manually via the Actions tab.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+# Required for the deploy-pages action to write to GitHub Pages.
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Do NOT cancel in-progress deployments — a partial deploy leaves the site broken.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+          cache: "pip"
+
+      - name: Install MkDocs Material
+        run: pip install "mkdocs-material>=9.5"
+
+      - name: Build site
+        # --strict turns warnings into errors so broken links don't ship silently.
+        run: mkdocs build --strict
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ dmypy.json
 .DS_Store
 Thumbs.db
 
+# MkDocs build output
+/site/
+
 # Project specific
 *.log
 /reports/

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PyPI version](https://img.shields.io/pypi/v/ragaliq.svg)](https://pypi.org/project/ragaliq/)
+[![CI](https://github.com/dariero/RagaliQ/actions/workflows/ci.yml/badge.svg)](https://github.com/dariero/RagaliQ/actions/workflows/ci.yml)
+[![Docs](https://github.com/dariero/RagaliQ/actions/workflows/docs.yml/badge.svg)](https://dariero.github.io/RagaliQ/)
 
 **RagaliQ** (**RAG** + **Quality**) is an open-source LLM/RAG testing toolkit that brings software testing discipline to Retrieval-Augmented Generation pipelines. It provides automated **hallucination detection**, **faithfulness metrics**, **answer relevance scoring**, **context precision**, and **context recall** evaluation — all powered by an LLM-as-Judge architecture. Write quality tests for your AI responses as naturally as you write unit tests with pytest.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+site_name: RagaliQ
+site_description: LLM & RAG Evaluation Testing Framework — hallucination detection, faithfulness metrics, and retrieval quality auditing with pytest integration
+site_url: https://dariero.github.io/RagaliQ/
+repo_url: https://github.com/dariero/RagaliQ
+repo_name: dariero/RagaliQ
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top        # Back-to-top button
+    - search.suggest
+    - search.highlight
+    - content.code.copy     # One-click copy button on all code blocks
+    - content.code.annotate # Inline code annotations
+
+nav:
+  - Home: index.md
+  - Tutorial: TUTORIAL.md
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition              # !!! note / !!! warning callout blocks
+  - tables
+  - toc:
+      permalink: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences    # Nested code blocks, mermaid diagrams
+  - pymdownx.tabbed:
+      alternate_style: true # Modern tabbed code examples
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/dariero/RagaliQ
+      name: GitHub
+    - icon: fontawesome/brands/python
+      link: https://pypi.org/project/ragaliq/
+      name: PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,9 @@ dependencies = [
 
 [project.optional-dependencies]
 openai = ["openai>=2.15.0"]
+docs = [
+    "mkdocs-material>=9.5",
+]
 dev = [
     "pytest>=9.0",
     "pytest-asyncio>=0.25",


### PR DESCRIPTION
Closes #72

## Changes

| File | Purpose |
|---|---|
| `mkdocs.yml` | MkDocs Material config — dark/light mode, instant search, code copy, tabbed content, social links |
| `.github/workflows/docs.yml` | Build with `--strict` + deploy to GitHub Pages on every push to main; `cancel-in-progress: false` protects in-flight deploys |
| `pyproject.toml` | New `docs` optional dependency group: `pip install ragaliq[docs]` |
| `README.md` | Added CI build status badge and Docs badge |
| `.gitignore` | Added `/site/` (MkDocs build output) |

## Docs URL

https://dariero.github.io/RagaliQ/

## Manual Step Required After Merge

**Settings → Pages → Source → GitHub Actions** (currently set to "Deploy from a branch").
Without this change, the `docs.yml` workflow will deploy but GitHub Pages will still serve the legacy Jekyll build.

## Quality Gates

- ✅ `hatch run lint` — All checks passed
- ✅ `hatch run test` — 630 passed, 1 skipped
- ✅ `mkdocs build --strict` — Built in 0.33s, no errors