### PR TITLE
[DOCS #74] Update Documentation URL to live MkDocs site

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ ragaliq = "ragaliq.integrations.pytest_plugin"
 
 [project.urls]
 Homepage = "https://github.com/dariero/RagaliQ"
-Documentation = "https://github.com/dariero/RagaliQ/blob/main/docs/TUTORIAL.md"
+Documentation = "https://dariero.github.io/RagaliQ/"
 Repository = "https://github.com/dariero/RagaliQ"
 Issues = "https://github.com/dariero/RagaliQ/issues"
 Changelog = "https://github.com/dariero/RagaliQ/blob/main/CHANGELOG.md"


### PR DESCRIPTION
Closes #74

## Changes

- Updated `[project.urls]` `Documentation` entry in `pyproject.toml` from the raw GitHub file path to the live MkDocs Material site

**Before:** `https://github.com/dariero/RagaliQ/blob/main/docs/TUTORIAL.md`
**After:** `https://dariero.github.io/RagaliQ/`

## Why

The PyPI package page sidebar and pip tooling display this URL as the project's documentation link. Now that the MkDocs site is live via GitHub Actions, this should point to the rendered site rather than a raw Markdown file on GitHub.

## Checks

- [x] `hatch run lint` — All checks passed
- [x] `hatch run test` — 630 passed, 1 skipped