### PR TITLE
Upgrade GitHub Actions and add evaluation demos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
           cache-dependency-glob: "pylock.toml"
@@ -43,13 +43,13 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
           cache-dependency-glob: "pylock.toml"
@@ -71,13 +71,13 @@ jobs:
       matrix:
         python-version: ["3.14"]
     steps:
-      - uses: actions/checkout@v6.0.3
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@v6.2.0
+      - uses: actions/setup-python@v6.3.0
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v8.2.0
+      - uses: astral-sh/setup-uv@v8.3.2
         with:
           enable-cache: true
           cache-dependency-glob: "pylock.toml"
@@ -90,7 +90,7 @@ jobs:
 
       - name: Run unit tests
         # --cov-report=xml writes coverage.xml for the Codecov upload below.
-        run: .venv/bin/pytest tests/unit/ --cov-report=xml
+        run: .venv/bin/pytest tests/unit/ tests/meta/test_meta_metrics.py --cov-report=xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7.0.0

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,9 +23,9 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
           cache: "pip"
@@ -38,7 +38,7 @@ jobs:
         run: mkdocs build --strict
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: site/
 
@@ -52,4 +52,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5.0.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     name: Validate Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
           cache: "pip"
@@ -26,7 +26,7 @@ jobs:
         run: pip install -e ".[dev]"
 
       - name: Run unit tests
-        run: pytest tests/unit/
+        run: pytest tests/unit/ tests/meta/test_meta_metrics.py
 
       - name: Verify version tag matches pyproject.toml
         # Strips the leading 'v' from the tag (v0.2.0 → 0.2.0) and compares
@@ -57,9 +57,9 @@ jobs:
     needs: [validate]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6.3.0
         with:
           python-version: "3.14"
           cache: "pip"
@@ -77,7 +77,7 @@ jobs:
           twine check dist/*
 
       - name: Upload distribution artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: dist
           path: dist/
@@ -109,13 +109,13 @@ jobs:
 
     steps:
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: dist
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@v1.14.0
 
   # ──────────────────────────────────────────────────────────────────────
   # Job 4: Build and Push Docker Image — to GitHub Container Registry (GHCR).
@@ -138,13 +138,13 @@ jobs:
       packages: write  # REQUIRED to push to GHCR
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4.4.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6.2.0
         with:
           images: ghcr.io/${{ github.repository_owner }}/ragaliq
           tags: |
@@ -161,7 +161,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7.3.0
         with:
           context: .
           push: true
@@ -183,18 +183,18 @@ jobs:
       contents: write  # REQUIRED to create releases and upload assets
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # Full history needed for release notes generation
 
       - name: Download distribution artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8.0.1
         with:
           name: dist
           path: dist/
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3.0.2
         with:
           files: dist/*
           generate_release_notes: true  # Auto-generates notes from merged PRs

--- a/Demo/demo.json
+++ b/Demo/demo.json
@@ -1,0 +1,27 @@
+{
+  "version": "1.0",
+  "metadata": {
+    "description": "RagaliQ live demo - one honest answer, one with a made-up fact",
+    "domain": "demo"
+  },
+  "test_cases": [
+    {
+      "id": "honest",
+      "name": "Honest answer (should PASS / green)",
+      "query": "What is the capital of France?",
+      "context": [
+        "France is a country in Western Europe. Its capital city is Paris."
+      ],
+      "response": "The capital of France is Paris."
+    },
+    {
+      "id": "hallucination",
+      "name": "Answer with a made-up fact (should FAIL / red)",
+      "query": "What is the capital of France?",
+      "context": [
+        "France is a country in Western Europe. Its capital city is Paris."
+      ],
+      "response": "The capital of France is Paris, a city of 90 million people that was founded by Napoleon in 1620."
+    }
+  ]
+}

--- a/Demo/report.html
+++ b/Demo/report.html
@@ -1,0 +1,324 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RagaliQ Evaluation Report</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+      background: #f0f2f5;
+      color: #1a1a1a;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+
+    header {
+      background: #0f172a;
+      color: #f1f5f9;
+      padding: 1.25rem 2rem;
+      display: flex;
+      align-items: baseline;
+      gap: 1.5rem;
+    }
+    header h1 { font-size: 1.25rem; font-weight: 600; letter-spacing: -0.01em; }
+    header .meta { font-size: 0.8rem; color: #94a3b8; }
+
+    .container { max-width: 1200px; margin: 1.5rem auto; padding: 0 1rem; }
+
+    /* ── Summary cards ── */
+    .cards {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(130px, 1fr));
+      gap: 0.75rem;
+      margin-bottom: 1.5rem;
+    }
+    .card {
+      background: #fff;
+      border-radius: 8px;
+      padding: 1rem 1.25rem;
+      box-shadow: 0 1px 3px rgba(0,0,0,.07);
+    }
+    .card .label {
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #6b7280;
+      margin-bottom: 0.3rem;
+    }
+    .card .value { font-size: 1.75rem; font-weight: 700; }
+    .card.c-pass  .value { color: #16a34a; }
+    .card.c-fail  .value { color: #dc2626; }
+    .card.c-error .value { color: #d97706; }
+    .card.c-rate  .value { color: #2563eb; }
+
+    /* ── Per-evaluator stats ── */
+    .section-title {
+      font-size: 0.75rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #6b7280;
+      margin-bottom: 0.5rem;
+    }
+    .ev-table-wrap { margin-bottom: 1.5rem; }
+    .ev-table {
+      background: #fff;
+      border-radius: 8px;
+      box-shadow: 0 1px 3px rgba(0,0,0,.07);
+      border-collapse: collapse;
+      width: auto;
+      min-width: 400px;
+    }
+    .ev-table th, .ev-table td {
+      padding: 0.5rem 1rem;
+      text-align: left;
+    }
+    .ev-table th {
+      background: #f8fafc;
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6b7280;
+      border-bottom: 1px solid #e5e7eb;
+    }
+    .ev-table td { border-bottom: 1px solid #f3f4f6; }
+    .ev-table tr:last-child td { border-bottom: none; }
+
+    /* ── Results table ── */
+    .results-wrap { overflow-x: auto; }
+    table.results {
+      width: 100%;
+      border-collapse: collapse;
+      background: #fff;
+      border-radius: 8px;
+      overflow: hidden;
+      box-shadow: 0 1px 3px rgba(0,0,0,.07);
+    }
+    table.results th {
+      background: #f8fafc;
+      padding: 0.6rem 1rem;
+      text-align: left;
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      color: #6b7280;
+      border-bottom: 2px solid #e5e7eb;
+      white-space: nowrap;
+    }
+    table.results td {
+      padding: 0.65rem 1rem;
+      border-bottom: 1px solid #f3f4f6;
+      vertical-align: top;
+    }
+    table.results tr:last-child td { border-bottom: none; }
+    table.results tr:hover td { background: #fafafa; }
+
+    .badge {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 4px;
+      font-size: 0.7rem;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    .badge-passed  { background: #dcfce7; color: #15803d; }
+    .badge-failed  { background: #fee2e2; color: #b91c1c; }
+    .badge-error   { background: #fef3c7; color: #b45309; }
+    .badge-skipped { background: #f3f4f6; color: #6b7280; }
+
+    .score-pass { color: #16a34a; font-weight: 600; }
+    .score-fail { color: #dc2626; font-weight: 600; }
+    .score-none { color: #9ca3af; }
+
+    /* ── Expandable failure details ── */
+    .detail-cell { background: #fafafa !important; padding: 0 !important; }
+    details { padding: 0.6rem 1rem 0.75rem; }
+    summary {
+      cursor: pointer;
+      font-size: 0.8rem;
+      color: #6b7280;
+      user-select: none;
+      list-style: none;
+    }
+    summary::before { content: "▶ "; font-size: 0.65rem; }
+    details[open] summary::before { content: "▼ "; }
+    summary:hover { color: #374151; }
+    .detail-item {
+      margin-top: 0.5rem;
+      font-size: 0.82rem;
+      padding-left: 1rem;
+      border-left: 2px solid #e5e7eb;
+    }
+    .detail-item .ev-label { color: #d97706; font-weight: 600; }
+    .detail-item .ev-error { color: #dc2626; }
+
+    /* ── Footer ── */
+    footer {
+      text-align: center;
+      padding: 2rem 1rem;
+      font-size: 0.75rem;
+      color: #9ca3af;
+    }
+  </style>
+</head>
+<body>
+
+<header>
+  <h1>RagaliQ Evaluation Report</h1>
+  <span class="meta">Generated 2026-06-04 04:00 UTC &nbsp;·&nbsp; Threshold 0.7</span>
+</header>
+
+<div class="container">
+
+  <!-- Summary cards -->
+  <div class="cards">
+    <div class="card">
+      <div class="label">Total</div>
+      <div class="value">2</div>
+    </div>
+    <div class="card c-pass">
+      <div class="label">Passed</div>
+      <div class="value">1</div>
+    </div>
+    <div class="card c-fail">
+      <div class="label">Failed</div>
+      <div class="value">1</div>
+    </div>
+
+    <div class="card c-rate">
+      <div class="label">Pass Rate</div>
+      <div class="value">50%</div>
+    </div>
+    <div class="card">
+      <div class="label">Tokens</div>
+      <div class="value" style="font-size:1.2rem">2,531</div>
+    </div>
+  </div>
+
+  <!-- Per-evaluator stats -->
+
+  <div class="ev-table-wrap">
+    <div class="section-title">Evaluator Summary</div>
+    <table class="ev-table">
+      <thead>
+        <tr>
+          <th>Evaluator</th>
+          <th>Passed</th>
+          <th>Failed</th>
+          <th>Avg Score</th>
+        </tr>
+      </thead>
+      <tbody>
+
+        <tr>
+          <td>faithfulness</td>
+          <td style="color:#16a34a;font-weight:600">1</td>
+          <td style="color:#dc2626;font-weight:600">1</td>
+          <td>0.625</td>
+        </tr>
+
+        <tr>
+          <td>relevance</td>
+          <td style="color:#16a34a;font-weight:600">2</td>
+          <td style="color:#6b7280;font-weight:400">0</td>
+          <td>0.900</td>
+        </tr>
+
+      </tbody>
+    </table>
+  </div>
+
+
+  <!-- Results table -->
+  <div class="section-title">Results</div>
+  <div class="results-wrap">
+    <table class="results">
+      <thead>
+        <tr>
+          <th>Test Case</th>
+          <th>Status</th>
+
+          <th>Faithfulness</th>
+
+          <th>Relevance</th>
+
+          <th>Time (ms)</th>
+        </tr>
+      </thead>
+      <tbody>
+
+        <tr>
+          <td>Honest answer (should PASS / green)</td>
+          <td><span class="badge badge-passed">passed</span></td>
+
+          <td>
+
+              <span class="score-pass">1.00</span>
+
+          </td>
+
+          <td>
+
+              <span class="score-pass">1.00</span>
+
+          </td>
+
+          <td style="color:#6b7280">3703</td>
+        </tr>
+
+
+        <tr>
+          <td>Answer with a made-up fact (should FAIL / red)</td>
+          <td><span class="badge badge-failed">failed</span></td>
+
+          <td>
+
+              <span class="score-fail">0.25</span>
+
+          </td>
+
+          <td>
+
+              <span class="score-pass">0.80</span>
+
+          </td>
+
+          <td style="color:#6b7280">4146</td>
+        </tr>
+
+        <tr>
+          <td class="detail-cell" colspan="5">
+            <details>
+              <summary>Failure details</summary>
+
+              <div class="detail-item">
+                <span class="ev-label">faithfulness</span>:
+
+                  1 of 4 claims are supported (25%). 3 claim(s) not grounded in context.
+
+              </div>
+
+            </details>
+          </td>
+        </tr>
+
+
+      </tbody>
+    </table>
+  </div>
+
+</div>
+
+<footer>
+  Generated by <strong>RagaliQ</strong> &nbsp;·&nbsp; 2026-06-04 04:00 UTC
+</footer>
+
+</body>
+</html>

--- a/demo_single_eval.py
+++ b/demo_single_eval.py
@@ -1,0 +1,93 @@
+"""Standalone learning script: run one RAGTestCase through RagaliQ.
+
+Run it two ways:
+
+    .venv/bin/python demo_single_eval.py            # clean (faithful) answer
+    .venv/bin/python demo_single_eval.py --corrupt  # answer with 1 unsupported claim
+
+Requires ANTHROPIC_API_KEY in the environment.
+"""
+
+from __future__ import annotations
+
+import sys
+
+from ragaliq import RagaliQ, RAGTestCase
+
+# --- The shared "retrieval" side of a RAG test case --------------------------
+# In a real RAG system, `context` is whatever your retriever pulled from the
+# vector store for this question. Here we hand-write it so we control exactly
+# what the answer is *allowed* to be grounded in.
+QUERY = "What is the capital of France?"
+CONTEXT = [
+    "France is a country in Western Europe.",
+    "The capital city of France is Paris, home to the Eiffel Tower.",
+]
+
+# --- Two versions of the generated answer -----------------------------------
+# CLEAN: every statement is backed by the context above.
+CLEAN_RESPONSE = "The capital of France is Paris."
+
+# CORRUPT: same correct first claim, PLUS one on-topic but UNSUPPORTED claim.
+# The population figure appears nowhere in CONTEXT, so the judge cannot ground it.
+CORRUPT_RESPONSE = (
+    "The capital of France is Paris, and Paris has a population of 30 million people."
+)
+
+
+def build_test_case(corrupt: bool) -> RAGTestCase:
+    """Construct the RAGTestCase, choosing the clean or corrupted answer."""
+    return RAGTestCase(
+        id="demo-france-1",  # unique id (like a test name)
+        name="Capital of France" + (" (corrupted)" if corrupt else ""),
+        query=QUERY,  # the user's question
+        context=CONTEXT,  # retrieved docs the answer may use
+        response=CORRUPT_RESPONSE if corrupt else CLEAN_RESPONSE,  # the answer under test
+    )
+
+
+def main() -> None:
+    corrupt = "--corrupt" in sys.argv
+
+    test_case = build_test_case(corrupt)
+
+    # RagaliQ() with defaults = Claude judge, evaluators [faithfulness, relevance],
+    # passing threshold 0.7. .evaluate() runs synchronously (wraps asyncio internally).
+    tester = RagaliQ(judge="claude")
+
+    print(f"\n=== Variant: {'CORRUPTED' if corrupt else 'CLEAN'} ===")
+    print(f"Question : {test_case.query}")
+    print(f"Answer   : {test_case.response}")
+    print(f"Context  : {test_case.context}")
+
+    result = tester.evaluate(test_case)
+
+    print(f"\nStatus       : {result.status}  (passed={result.passed})")
+    print(f"Tokens used  : {result.judge_tokens_used}")
+    print(f"Time         : {result.execution_time_ms} ms")
+
+    print("\nScores (threshold 0.70):")
+    for metric, score in result.scores.items():
+        mark = "PASS" if score >= 0.70 else "FAIL"
+        print(f"  [{mark}] {metric:<13} {score:.2f}")
+
+    # Faithfulness exposes its per-claim breakdown in the 'raw' detail —
+    # this is what makes the score explainable rather than a black box.
+    faith = result.details["faithfulness"]
+    print("\nFaithfulness reasoning:")
+    print(f"  {faith['reasoning']}")
+    claims = faith["raw"].get("claims", [])
+    if claims:
+        print("  Per-claim verdicts:")
+        for c in claims:
+            print(f"    - [{c['verdict']}] {c['claim']}")
+            if c.get("evidence"):
+                print(f"        evidence: {c['evidence']}")
+
+    print("\nRelevance reasoning:")
+    print(f"  {result.details['relevance']['reasoning']}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/demos/keyword_rag.py
+++ b/demos/keyword_rag.py
@@ -1,0 +1,116 @@
+"""Unstructured-retrieval RAG: keyword search over text with SQLite FTS5.
+
+This is the *retrieval half* of a tiny RAG system under test (SUT). It has zero
+external dependencies — only Python's built-in ``sqlite3`` with the FTS5
+full-text-search engine.
+
+Phase A, step 1 (A1): build the index and prove ``retrieve(query)`` returns the
+right passages. No LLM calls happen here; this step costs nothing.
+
+Run it directly to see retrieval in action::
+
+    .venv/bin/python demos/keyword_rag.py
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+
+# --- The knowledge base ------------------------------------------------------
+# Deliberately FICTIONAL facts about a made-up city-state. Fiction matters: it
+# forces any correct answer to come from THESE passages, not from the model's
+# training data. That is what makes a faithfulness score meaningful later.
+FACTS: list[str] = [
+    "Zentra is a fictional island city-state founded in the year 1820.",
+    "The official currency of Zentra is the zent, abbreviated ZT.",
+    "Zentra's national dish is grilled saltfish served with roasted yam.",
+    "The tallest building in Zentra is the Vox Tower, which stands 410 meters tall.",
+    "Every October, Zentra celebrates a harvest festival called Lumen.",
+    "The official language of Zentra is Calic, spoken by most residents.",
+]
+
+# Tiny stopword set so question words ("what", "is", "the") don't dominate the
+# keyword query. A real system would use a proper tokenizer; this keeps the demo
+# transparent — you can see exactly which words drive the search.
+_STOPWORDS = frozenset(
+    {"the", "is", "of", "a", "an", "what", "when", "where", "who", "how", "are", "does", "did"}
+)
+
+
+def build_index(conn: sqlite3.Connection) -> None:
+    """Create an FTS5 virtual table and load the facts into it.
+
+    Args:
+        conn: An open SQLite connection (typically in-memory).
+    """
+    conn.execute("CREATE VIRTUAL TABLE facts USING fts5(body)")
+    conn.executemany("INSERT INTO facts(body) VALUES (?)", [(fact,) for fact in FACTS])
+
+
+def to_match_query(query: str) -> str:
+    """Turn a natural-language question into an FTS5 keyword expression.
+
+    FTS5's ``MATCH`` treats characters like ``?`` and quotes as query syntax and
+    raises on them, so we extract bare alphanumeric keywords, drop stopwords, and
+    join the rest with ``OR``.
+
+    Args:
+        query: The user's natural-language question.
+
+    Returns:
+        An ``OR``-joined keyword string (empty if the query has no usable terms).
+    """
+    tokens = re.findall(r"[a-z0-9]+", query.lower())
+    keywords = [tok for tok in tokens if tok not in _STOPWORDS]
+    return " OR ".join(keywords)
+
+
+def retrieve(conn: sqlite3.Connection, query: str, k: int = 2) -> list[str]:
+    """Return the top-``k`` passages matching ``query``, ranked by relevance.
+
+    Args:
+        conn: An open SQLite connection with the FTS5 index built.
+        query: The user's natural-language question.
+        k: Maximum number of passages to return.
+
+    Returns:
+        The matching passage strings, best match first. Empty if nothing matches.
+    """
+    match = to_match_query(query)
+    if not match:
+        return []
+    rows = conn.execute(
+        "SELECT body FROM facts WHERE facts MATCH ? ORDER BY rank LIMIT ?",
+        (match, k),
+    ).fetchall()
+    return [row[0] for row in rows]
+
+
+def main() -> None:
+    """Build the index and demonstrate retrieval for a few sample questions."""
+    conn = sqlite3.connect(":memory:")
+    build_index(conn)
+
+    questions = [
+        "What is the currency of Zentra?",
+        "How tall is the Vox Tower?",
+        "When is the Lumen festival held?",
+    ]
+
+    print(f"Indexed {len(FACTS)} facts into an FTS5 table.\n")
+    for question in questions:
+        match = to_match_query(question)
+        passages = retrieve(conn, question, k=2)
+        print(f"Q: {question}")
+        print(f"   MATCH expression : {match}")
+        print(f"   retrieved ({len(passages)}):")
+        for passage in passages:
+            print(f"     - {passage}")
+        print()
+
+    conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,10 @@ plugins = ["pydantic.mypy"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "-v --cov=ragaliq --cov-report=term-missing"
+addopts = "-v --cov=ragaliq --cov-report=term-missing -m 'not meta'"
+markers = [
+    "meta: paid live judge-quality evaluation; requires explicit opt-in",
+]
 
 [tool.coverage.run]
 source_pkgs = ["ragaliq"]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""RagaliQ test suite."""

--- a/tests/meta/__init__.py
+++ b/tests/meta/__init__.py
@@ -1,0 +1,1 @@
+"""Judge meta-evaluation tests and golden datasets."""

--- a/tests/meta/conftest.py
+++ b/tests/meta/conftest.py
@@ -1,0 +1,59 @@
+"""Fixtures and configuration for the meta-evaluation suite.
+
+The live tests here make real API calls and cost money, so they are:
+  - gated behind the `meta` marker
+  - enabled explicitly with RAGALIQ_RUN_META=1
+  - skipped automatically when ANTHROPIC_API_KEY is absent
+
+The harness/metric tests (test_meta_metrics.py) are NOT gated — they run in CI
+with no network using a StubJudge.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+import pytest
+
+from tests.meta.meta_metrics import (
+    GoldenCase,
+    GoldenClaim,
+    load_golden_cases,
+    load_golden_claims,
+)
+
+if TYPE_CHECKING:
+    from ragaliq.judges.base import LLMJudge
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Register the `meta` marker for live judge-quality benchmarks."""
+    config.addinivalue_line(
+        "markers",
+        "meta: live judge meta-evaluation against the golden set (needs ANTHROPIC_API_KEY)",
+    )
+
+
+@pytest.fixture
+def golden_claims() -> list[GoldenClaim]:
+    """The human-labelled claim-verdict golden set."""
+    return load_golden_claims()
+
+
+@pytest.fixture
+def golden_cases() -> list[GoldenCase]:
+    """The case-level faithfulness golden set."""
+    return load_golden_cases()
+
+
+@pytest.fixture
+def live_judge() -> LLMJudge:
+    """A real ClaudeJudge. Skips the test cleanly if no API key is configured."""
+    if os.getenv("RAGALIQ_RUN_META") != "1":
+        pytest.skip("set RAGALIQ_RUN_META=1 to enable paid meta-evaluation")
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        pytest.skip("ANTHROPIC_API_KEY not set; skipping live meta-evaluation")
+    from ragaliq.judges.claude import ClaudeJudge
+
+    return ClaudeJudge()

--- a/tests/meta/golden/claim_verdicts.yaml
+++ b/tests/meta/golden/claim_verdicts.yaml
@@ -1,0 +1,112 @@
+# Golden claim-verdict set for judge meta-evaluation.
+#
+# Each item is an ATOMIC claim + context, labelled by a human with the verdict
+# the judge SHOULD return. Atomic = a single verifiable fact, so the human label
+# is unambiguous (this mirrors what extract_claims() is meant to produce).
+#
+# `expected` is the human ground truth. The meta-eval measures how often the live
+# judge (verify_claim) agrees with these labels. `note` records the human rationale
+# so the label provenance is auditable — that is what makes this a golden set and
+# not just more test data.
+#
+# Verdicts: SUPPORTED | CONTRADICTED | NOT_ENOUGH_INFO
+
+items:
+  - id: sup_explicit
+    claim: "Paris is the capital of France."
+    context:
+      - "France is a country in Western Europe. Its capital city is Paris."
+    expected: SUPPORTED
+    note: "Context states the fact verbatim."
+
+  - id: sup_paraphrase
+    claim: "Water boils at 100 degrees Celsius at sea level."
+    context:
+      - "At standard atmospheric pressure, the boiling point of water is 100 C."
+    expected: SUPPORTED
+    note: "Supported via paraphrase; 'sea level' == 'standard atmospheric pressure'."
+
+  - id: sup_multi_doc
+    claim: "The Amazon River is in South America."
+    context:
+      - "The Nile is the longest river in Africa."
+      - "The Amazon River flows through South America and is the largest by discharge."
+    expected: SUPPORTED
+    note: "Support lives in the second document; tests multi-chunk handling."
+
+  - id: sup_inference
+    claim: "A hexagon has more sides than a square."
+    context:
+      - "A square has four sides. A hexagon has six sides."
+    expected: SUPPORTED
+    note: "Requires trivial comparison (6 > 4) directly entailed by context."
+
+  - id: con_numeric
+    claim: "Paris has a population of 5 million people."
+    context:
+      - "Paris is the capital of France. The city proper has about 2.1 million residents."
+    expected: CONTRADICTED
+    note: "Context gives 2.1M, claim says 5M — direct numeric contradiction."
+
+  - id: con_negation
+    claim: "The Pacific is the smallest ocean."
+    context:
+      - "The Pacific Ocean is the largest and deepest of Earth's oceans."
+    expected: CONTRADICTED
+    note: "Largest vs smallest — explicit contradiction."
+
+  - id: con_attribute
+    claim: "Mercury is the hottest planet in the solar system."
+    context:
+      - "Although Mercury is closest to the Sun, Venus is the hottest planet due to its dense atmosphere."
+    expected: CONTRADICTED
+    note: "Context explicitly assigns 'hottest' to Venus, not Mercury."
+
+  - id: nei_topic_present_fact_absent
+    claim: "The Eiffel Tower was completed in 1889."
+    context:
+      - "Paris landmarks include the Eiffel Tower, the Louvre, and Notre-Dame."
+    expected: NOT_ENOUGH_INFO
+    note: "Eiffel Tower is mentioned but no construction date is given."
+
+  - id: nei_distractor
+    claim: "Photosynthesis converts light into chemical energy."
+    context:
+      - "The 2018 budget allocated funds to road maintenance and public transport."
+    expected: NOT_ENOUGH_INFO
+    note: "Context is unrelated; neither supports nor contradicts."
+
+  - id: nei_adjacent_but_silent
+    claim: "Insulin is produced in the pancreas."
+    context:
+      - "The pancreas is an organ located behind the stomach in the abdomen."
+    expected: NOT_ENOUGH_INFO
+    note: "Context describes the pancreas's location but says nothing about insulin."
+
+  - id: sup_definitional
+    claim: "A triangle has three sides."
+    context:
+      - "A triangle is a polygon defined by three edges and three vertices."
+    expected: SUPPORTED
+    note: "Direct definitional support; 'edges' == 'sides'."
+
+  - id: con_date
+    claim: "World War II ended in 1939."
+    context:
+      - "World War II began in 1939 and ended in 1945."
+    expected: CONTRADICTED
+    note: "1939 is the start; context states the end as 1945."
+
+  - id: nei_partial_entity
+    claim: "Ada Lovelace wrote the first computer program."
+    context:
+      - "Ada Lovelace worked with Charles Babbage on the Analytical Engine."
+    expected: NOT_ENOUGH_INFO
+    note: "Association is present but the specific 'first program' claim is not stated."
+
+  - id: sup_units
+    claim: "There are 1000 metres in a kilometre."
+    context:
+      - "The kilometre is a unit of length equal to one thousand metres."
+    expected: SUPPORTED
+    note: "Exact numeric support via wording ('one thousand')."

--- a/tests/meta/golden/faithfulness_cases.yaml
+++ b/tests/meta/golden/faithfulness_cases.yaml
@@ -1,0 +1,53 @@
+# Case-level golden set for end-to-end faithfulness scoring.
+#
+# Unlike claim_verdicts.yaml (which labels the judge's atomic decision), this set
+# labels the FaithfulnessEvaluator's emitted score on a full (query, context,
+# response) tuple. Because claim extraction count varies slightly run to run, the
+# human label is a BAND, not an exact value. The meta-eval asserts the score lands
+# inside the band and reports MAE against the band midpoint as a continuous signal.
+
+cases:
+  - id: fully_faithful
+    query: "What is the capital of France?"
+    context:
+      - "France is a country in Western Europe."
+      - "The capital city of France is Paris."
+    response: "The capital of France is Paris."
+    expected_band: [0.9, 1.0]
+    note: "Single claim, fully grounded."
+
+  - id: one_hallucinated_of_two
+    query: "Tell me about Paris."
+    context:
+      - "Paris is the capital of France."
+      - "Paris sits on the Seine river."
+    response: "Paris is the capital of France and was founded by Julius Caesar in 50 BC."
+    expected_band: [0.4, 0.7]
+    note: "One supported claim (capital), one fabricated (founding) — roughly half."
+
+  - id: fully_hallucinated
+    query: "What is the boiling point of water?"
+    context:
+      - "Water is a chemical compound with the formula H2O."
+    response: "Water boils at 350 degrees and is primarily composed of helium."
+    expected_band: [0.0, 0.25]
+    note: "No claim is supported by the context."
+
+  - id: faithful_multi_claim
+    query: "Describe the solar system's inner planets."
+    context:
+      - "Mercury is the closest planet to the Sun."
+      - "Venus is the hottest planet due to its dense atmosphere."
+      - "Earth is the third planet from the Sun."
+    response: "Mercury is closest to the Sun, Venus is the hottest planet, and Earth is third from the Sun."
+    expected_band: [0.9, 1.0]
+    note: "Three claims, all grounded."
+
+  - id: mostly_faithful_one_drift
+    query: "What do we know about the pancreas?"
+    context:
+      - "The pancreas is an organ behind the stomach."
+      - "It plays a role in digestion."
+    response: "The pancreas sits behind the stomach, aids digestion, and is the largest organ in the body."
+    expected_band: [0.55, 0.8]
+    note: "Two grounded claims, one unsupported ('largest organ')."

--- a/tests/meta/meta_metrics.py
+++ b/tests/meta/meta_metrics.py
@@ -1,0 +1,329 @@
+"""
+Meta-evaluation metrics and harness for RagaliQ.
+
+This module answers the question the rest of the test suite does not:
+*is the judge itself any good?* Everything in tests/unit and tests/integration
+assumes the judge's verdict is ground truth. Here we compare the live judge's
+verdicts against a human-labelled golden set and quantify agreement.
+
+The module is deliberately dependency-light (stdlib + pyyaml, both already
+required) and split into two halves:
+
+1. PURE FUNCTIONS — confusion matrix, precision/recall/F1, accuracy, Cohen's
+   kappa, score-band checks. No I/O, no judge, fully unit-testable.
+2. ASYNC HARNESS — run_claim_agreement(): loops a golden set through any
+   LLMJudge's verify_claim() and returns an AgreementReport. Depends only on the
+   LLMJudge protocol, so it works with the real ClaudeJudge or a stub.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, TypedDict, cast
+
+import yaml
+
+if TYPE_CHECKING:
+    from ragaliq.judges.base import LLMJudge
+
+VERDICTS: tuple[str, ...] = ("SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO")
+
+_GOLDEN_DIR = Path(__file__).parent / "golden"
+_BASELINE_DIR = Path(__file__).parent / "baselines"
+
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GoldenClaim:
+    """A single human-labelled (claim, context) -> verdict triple."""
+
+    id: str
+    claim: str
+    context: list[str]
+    expected: str
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class GoldenCase:
+    """A human-labelled full RAG case with an expected faithfulness score band."""
+
+    id: str
+    query: str
+    context: list[str]
+    response: str
+    expected_band: tuple[float, float]
+    note: str = ""
+
+
+@dataclass(frozen=True)
+class ClassMetrics:
+    """Precision/recall/F1 for one verdict class."""
+
+    precision: float
+    recall: float
+    f1: float
+    support: int  # number of golden items whose true label is this class
+
+
+class ClassMetricsSnapshot(TypedDict):
+    """JSON-safe form of one verdict class's metrics."""
+
+    precision: float
+    recall: float
+    f1: float
+    support: int
+
+
+class AgreementSnapshot(TypedDict):
+    """JSON-safe subset of an agreement report used for drift checks."""
+
+    model: str
+    n: int
+    accuracy: float
+    cohen_kappa: float
+    macro_f1: float
+    per_class: dict[str, ClassMetricsSnapshot]
+
+
+@dataclass
+class AgreementReport:
+    """Result of comparing judge verdicts against the golden labels."""
+
+    model: str
+    n: int
+    accuracy: float
+    cohen_kappa: float
+    macro_f1: float
+    per_class: dict[str, ClassMetrics]
+    confusion: dict[str, dict[str, int]]  # confusion[true][pred] = count
+    disagreements: list[dict[str, str]] = field(default_factory=list)
+
+    def to_snapshot(self) -> AgreementSnapshot:
+        """Flatten to a JSON-serialisable snapshot for drift regression."""
+        return {
+            "model": self.model,
+            "n": self.n,
+            "accuracy": round(self.accuracy, 4),
+            "cohen_kappa": round(self.cohen_kappa, 4),
+            "macro_f1": round(self.macro_f1, 4),
+            "per_class": {
+                label: {
+                    "precision": metrics.precision,
+                    "recall": metrics.recall,
+                    "f1": metrics.f1,
+                    "support": metrics.support,
+                }
+                for label, metrics in self.per_class.items()
+            },
+        }
+
+
+# ---------------------------------------------------------------------------
+# Loaders
+# ---------------------------------------------------------------------------
+
+
+def load_golden_claims(path: Path | None = None) -> list[GoldenClaim]:
+    """Load the human-labelled claim-verdict golden set."""
+    p = path or (_GOLDEN_DIR / "claim_verdicts.yaml")
+    raw = yaml.safe_load(p.read_text(encoding="utf-8"))
+    return [
+        GoldenClaim(
+            id=item["id"],
+            claim=item["claim"],
+            context=list(item["context"]),
+            expected=item["expected"],
+            note=item.get("note", ""),
+        )
+        for item in raw["items"]
+    ]
+
+
+def load_golden_cases(path: Path | None = None) -> list[GoldenCase]:
+    """Load the case-level faithfulness golden set."""
+    p = path or (_GOLDEN_DIR / "faithfulness_cases.yaml")
+    raw = yaml.safe_load(p.read_text(encoding="utf-8"))
+    return [
+        GoldenCase(
+            id=item["id"],
+            query=item["query"],
+            context=list(item["context"]),
+            response=item["response"],
+            expected_band=(float(item["expected_band"][0]), float(item["expected_band"][1])),
+            note=item.get("note", ""),
+        )
+        for item in raw["cases"]
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Pure metrics
+# ---------------------------------------------------------------------------
+
+
+def build_confusion(expected: list[str], predicted: list[str]) -> dict[str, dict[str, int]]:
+    """Build a confusion matrix as confusion[true_label][pred_label] = count.
+
+    Unknown predicted labels (a judge returning something off-schema) are folded
+    into a synthetic 'OTHER' column so they count as errors rather than crashing.
+    """
+    if len(expected) != len(predicted):
+        raise ValueError("expected and predicted must be the same length")
+
+    cols = (*VERDICTS, "OTHER")
+    matrix = {true_label: dict.fromkeys(cols, 0) for true_label in VERDICTS}
+    for true_label, pred_label in zip(expected, predicted, strict=True):
+        if true_label not in matrix:
+            raise ValueError(f"Unknown true label: {true_label!r}")
+        col = pred_label if pred_label in VERDICTS else "OTHER"
+        matrix[true_label][col] += 1
+    return matrix
+
+
+def accuracy(expected: list[str], predicted: list[str]) -> float:
+    """Fraction of items where judge agrees with the human label."""
+    if not expected:
+        return 0.0
+    correct = sum(1 for e, p in zip(expected, predicted, strict=True) if e == p)
+    return correct / len(expected)
+
+
+def class_metrics(confusion: dict[str, dict[str, int]], label: str) -> ClassMetrics:
+    """Precision/recall/F1 for one class from the confusion matrix."""
+    tp = confusion[label][label]
+    # Predicted == label across all true rows, minus the true positives.
+    predicted_positives = sum(confusion[t].get(label, 0) for t in confusion)
+    fp = predicted_positives - tp
+    # Actual == label (the row total), minus true positives.
+    actual_positives = sum(confusion[label].values())
+    fn = actual_positives - tp
+
+    precision = tp / (tp + fp) if (tp + fp) else 0.0
+    recall = tp / (tp + fn) if (tp + fn) else 0.0
+    f1 = (2 * precision * recall / (precision + recall)) if (precision + recall) else 0.0
+    return ClassMetrics(precision=precision, recall=recall, f1=f1, support=actual_positives)
+
+
+def macro_f1(confusion: dict[str, dict[str, int]]) -> float:
+    """Unweighted mean F1 across the three verdict classes."""
+    f1s = [class_metrics(confusion, label).f1 for label in VERDICTS]
+    return sum(f1s) / len(f1s) if f1s else 0.0
+
+
+def cohen_kappa(expected: list[str], predicted: list[str]) -> float:
+    """Cohen's kappa: agreement corrected for chance.
+
+    kappa = (p_o - p_e) / (1 - p_e)
+      p_o = observed agreement (= accuracy)
+      p_e = agreement expected by chance from the marginal label distributions
+
+    Range: 1.0 perfect, 0.0 chance-level, negative worse than chance. For a
+    three-way judge, >0.6 is 'substantial', >0.8 is 'near-perfect'.
+    """
+    n = len(expected)
+    if n == 0:
+        return 0.0
+
+    labels = sorted(set(expected) | set(predicted))
+    exp_counts = {label: expected.count(label) for label in labels}
+    pred_counts = {label: predicted.count(label) for label in labels}
+
+    p_o = accuracy(expected, predicted)
+    p_e = sum((exp_counts[label] / n) * (pred_counts[label] / n) for label in labels)
+
+    if p_e == 1.0:
+        # Degenerate: everything is one label and both agree on it.
+        return 1.0 if p_o == 1.0 else 0.0
+    return (p_o - p_e) / (1 - p_e)
+
+
+def in_band(score: float, band: tuple[float, float]) -> bool:
+    """Whether a score falls inside the human-labelled band (inclusive)."""
+    low, high = band
+    return low <= score <= high
+
+
+def band_mae(scores: list[float], bands: list[tuple[float, float]]) -> float:
+    """Mean absolute error of scores against their band midpoints."""
+    if not scores:
+        return 0.0
+    total = 0.0
+    for score, (low, high) in zip(scores, bands, strict=True):
+        midpoint = (low + high) / 2
+        total += abs(score - midpoint)
+    return total / len(scores)
+
+
+# ---------------------------------------------------------------------------
+# Async agreement harness
+# ---------------------------------------------------------------------------
+
+
+async def run_claim_agreement(judge: LLMJudge, golden: list[GoldenClaim]) -> AgreementReport:
+    """Run the golden claim set through judge.verify_claim and score agreement.
+
+    Works with any LLMJudge implementation: the real ClaudeJudge for a live
+    benchmark, or a StubJudge for deterministic harness tests.
+    """
+    expected = [g.expected for g in golden]
+    predicted: list[str] = []
+    disagreements: list[dict[str, str]] = []
+    model = getattr(getattr(judge, "config", None), "model", "unknown")
+
+    for item in golden:
+        verdict = await judge.verify_claim(item.claim, item.context)
+        predicted.append(verdict.verdict)
+        if verdict.verdict != item.expected:
+            disagreements.append(
+                {
+                    "id": item.id,
+                    "claim": item.claim,
+                    "expected": item.expected,
+                    "predicted": verdict.verdict,
+                    "evidence": verdict.evidence,
+                }
+            )
+
+    confusion = build_confusion(expected, predicted)
+    return AgreementReport(
+        model=model,
+        n=len(golden),
+        accuracy=accuracy(expected, predicted),
+        cohen_kappa=cohen_kappa(expected, predicted),
+        macro_f1=macro_f1(confusion),
+        per_class={label: class_metrics(confusion, label) for label in VERDICTS},
+        confusion=confusion,
+        disagreements=disagreements,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Snapshot / baseline I/O for drift regression
+# ---------------------------------------------------------------------------
+
+
+def write_snapshot(report: AgreementReport, name: str = "judge_agreement_latest") -> Path:
+    """Persist a report snapshot under baselines/ for inspection and drift checks."""
+    _BASELINE_DIR.mkdir(parents=True, exist_ok=True)
+    path = _BASELINE_DIR / f"{name}.json"
+    path.write_text(json.dumps(report.to_snapshot(), indent=2), encoding="utf-8")
+    return path
+
+
+def load_baseline(name: str = "judge_agreement_baseline") -> AgreementSnapshot | None:
+    """Load a pinned baseline snapshot if one exists, else None.
+
+    Returning None on a missing baseline lets the first live run establish the
+    baseline manually (copy latest -> baseline) rather than failing.
+    """
+    path = _BASELINE_DIR / f"{name}.json"
+    if not path.exists():
+        return None
+    return cast(AgreementSnapshot, json.loads(path.read_text(encoding="utf-8")))

--- a/tests/meta/test_judge_agreement.py
+++ b/tests/meta/test_judge_agreement.py
@@ -1,0 +1,85 @@
+"""Live judge-agreement benchmark (the actual meta-evaluation).
+
+Runs the real ClaudeJudge over the human-labelled golden set and measures how
+often it agrees. This is the only test in the repo that answers 'is the judge
+good?' rather than 'does the plumbing work?'.
+
+Gated behind the `meta` marker and an explicit paid-evaluation opt-in:
+
+    RAGALIQ_RUN_META=1 pytest -m meta
+
+On each run it writes baselines/judge_agreement_latest.json. To pin a baseline
+for drift detection, copy it once:
+
+    cp tests/meta/baselines/judge_agreement_latest.json \
+        tests/meta/baselines/judge_agreement_baseline.json
+
+Thereafter the test fails if macro-F1 regresses past MACRO_F1_DRIFT_TOLERANCE —
+your early-warning for a model-version change quietly degrading judge quality.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ragaliq.judges.base import LLMJudge
+from tests.meta.meta_metrics import (
+    GoldenClaim,
+    load_baseline,
+    run_claim_agreement,
+    write_snapshot,
+)
+
+# Absolute floors for the very first run (no baseline yet). Conservative: a
+# usable three-way judge should clear these comfortably. Tighten as you learn
+# your judge's real numbers.
+MIN_ACCURACY = 0.70
+MIN_KAPPA = 0.50  # 'moderate' agreement beyond chance
+MIN_MACRO_F1 = 0.65
+
+# How much macro-F1 may drop versus a pinned baseline before it's a regression.
+MACRO_F1_DRIFT_TOLERANCE = 0.10
+
+pytestmark = pytest.mark.meta
+
+
+async def test_judge_agreement_against_golden(
+    live_judge: LLMJudge, golden_claims: list[GoldenClaim]
+) -> None:
+    report = await run_claim_agreement(live_judge, golden_claims)
+    snapshot_path = write_snapshot(report)
+
+    # Human-readable diagnostics on failure.
+    print(f"\nJudge agreement ({report.model}, n={report.n}):")
+    print(f"  accuracy   = {report.accuracy:.3f}")
+    print(f"  cohen_kappa= {report.cohen_kappa:.3f}")
+    print(f"  macro_f1   = {report.macro_f1:.3f}")
+    for label, m in report.per_class.items():
+        print(f"  {label:<16} P={m.precision:.2f} R={m.recall:.2f} F1={m.f1:.2f} n={m.support}")
+    if report.disagreements:
+        print("  disagreements:")
+        for d in report.disagreements:
+            print(f"    [{d['id']}] expected {d['expected']} got {d['predicted']}: {d['claim']}")
+    print(f"  snapshot -> {snapshot_path}")
+
+    # Absolute floors.
+    assert report.accuracy >= MIN_ACCURACY, (
+        f"judge accuracy {report.accuracy:.3f} below floor {MIN_ACCURACY}"
+    )
+    assert report.cohen_kappa >= MIN_KAPPA, (
+        f"judge kappa {report.cohen_kappa:.3f} below floor {MIN_KAPPA}"
+    )
+    assert report.macro_f1 >= MIN_MACRO_F1, (
+        f"judge macro-F1 {report.macro_f1:.3f} below floor {MIN_MACRO_F1}"
+    )
+
+    # Drift regression against a pinned baseline, if one exists.
+    baseline = load_baseline()
+    if baseline is not None:
+        delta = baseline["macro_f1"] - report.macro_f1
+        assert delta <= MACRO_F1_DRIFT_TOLERANCE, (
+            f"macro-F1 regressed {delta:.3f} vs baseline "
+            f"({baseline['macro_f1']:.3f} -> {report.macro_f1:.3f}, "
+            f"model {baseline.get('model')} -> {report.model}); "
+            f"exceeds tolerance {MACRO_F1_DRIFT_TOLERANCE}"
+        )

--- a/tests/meta/test_meta_metrics.py
+++ b/tests/meta/test_meta_metrics.py
@@ -1,0 +1,264 @@
+"""CI-safe tests for the meta-evaluation math and harness.
+
+No network. These prove the *meta-eval itself* is correct: that the confusion
+matrix, F1, Cohen's kappa, and the agreement harness compute what we claim. A
+StubJudge with hard-coded verdicts lets us assert exact numbers.
+
+This mirrors RagaliQ's own philosophy: test the tester before trusting it.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from ragaliq.judges.base import (
+    ClaimsResult,
+    ClaimVerdict,
+    GeneratedAnswerResult,
+    GeneratedQuestionsResult,
+    JudgeResult,
+    LLMJudge,
+)
+from tests.meta.meta_metrics import (
+    accuracy,
+    band_mae,
+    build_confusion,
+    class_metrics,
+    cohen_kappa,
+    in_band,
+    load_golden_cases,
+    load_golden_claims,
+    macro_f1,
+    run_claim_agreement,
+)
+
+# ---------------------------------------------------------------------------
+# StubJudge: returns canned verdicts keyed by claim text. Network-free.
+# ---------------------------------------------------------------------------
+
+
+class StubJudge(LLMJudge):
+    """LLMJudge whose verify_claim returns a verdict from a lookup table.
+
+    Only verify_claim is exercised by the claim-agreement harness; the other
+    abstract methods are implemented as inert stubs to satisfy the interface.
+    """
+
+    def __init__(self, verdict_by_claim: dict[str, str]) -> None:
+        super().__init__()
+        self._verdicts = verdict_by_claim
+
+    async def verify_claim(self, claim: str, context: list[str]) -> ClaimVerdict:
+        del context
+        verdict = self._verdicts.get(claim, "NOT_ENOUGH_INFO")
+        return ClaimVerdict(verdict=verdict, evidence="stub", tokens_used=0)
+
+    async def evaluate_faithfulness(self, response: str, context: list[str]) -> JudgeResult:
+        del response, context
+        return JudgeResult(score=0.0, reasoning="stub", tokens_used=0)
+
+    async def evaluate_relevance(self, query: str, response: str) -> JudgeResult:
+        del query, response
+        return JudgeResult(score=0.0, reasoning="stub", tokens_used=0)
+
+    async def extract_claims(self, response: str) -> ClaimsResult:
+        del response
+        return ClaimsResult(claims=[], tokens_used=0)
+
+    async def generate_questions(self, documents: list[str], n: int) -> GeneratedQuestionsResult:
+        del documents, n
+        return GeneratedQuestionsResult(questions=[], tokens_used=0)
+
+    async def generate_answer(self, question: str, context: list[str]) -> GeneratedAnswerResult:
+        del question, context
+        return GeneratedAnswerResult(answer="", tokens_used=0)
+
+
+# ---------------------------------------------------------------------------
+# Confusion matrix
+# ---------------------------------------------------------------------------
+
+
+def test_confusion_perfect_agreement() -> None:
+    expected = ["SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO"]
+    matrix = build_confusion(expected, expected)
+    assert matrix["SUPPORTED"]["SUPPORTED"] == 1
+    assert matrix["CONTRADICTED"]["CONTRADICTED"] == 1
+    assert matrix["NOT_ENOUGH_INFO"]["NOT_ENOUGH_INFO"] == 1
+
+
+def test_confusion_off_schema_label_folds_to_other() -> None:
+    matrix = build_confusion(["SUPPORTED"], ["GARBAGE"])
+    assert matrix["SUPPORTED"]["OTHER"] == 1
+    assert matrix["SUPPORTED"]["SUPPORTED"] == 0
+
+
+def test_confusion_length_mismatch_raises() -> None:
+    with pytest.raises(ValueError, match="same length"):
+        build_confusion(["SUPPORTED"], [])
+
+
+# ---------------------------------------------------------------------------
+# Accuracy
+# ---------------------------------------------------------------------------
+
+
+def test_accuracy_half() -> None:
+    expected = ["SUPPORTED", "SUPPORTED", "CONTRADICTED", "CONTRADICTED"]
+    predicted = ["SUPPORTED", "CONTRADICTED", "CONTRADICTED", "SUPPORTED"]
+    assert accuracy(expected, predicted) == 0.5
+
+
+def test_accuracy_empty() -> None:
+    assert accuracy([], []) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Precision / recall / F1
+# ---------------------------------------------------------------------------
+
+
+def test_class_metrics_hand_computed() -> None:
+    # SUPPORTED: 2 true. Judge predicts SUPPORTED 3x: 2 correct, 1 false positive.
+    expected = ["SUPPORTED", "SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO"]
+    predicted = ["SUPPORTED", "SUPPORTED", "SUPPORTED", "NOT_ENOUGH_INFO"]
+    matrix = build_confusion(expected, predicted)
+    m = class_metrics(matrix, "SUPPORTED")
+    # TP=2, FP=1 (the CONTRADICTED item predicted SUPPORTED), FN=0
+    assert m.precision == pytest.approx(2 / 3)
+    assert m.recall == pytest.approx(1.0)
+    assert m.f1 == pytest.approx(2 * (2 / 3) * 1.0 / ((2 / 3) + 1.0))
+    assert m.support == 2
+
+
+def test_macro_f1_perfect() -> None:
+    expected = ["SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO"]
+    matrix = build_confusion(expected, expected)
+    assert macro_f1(matrix) == pytest.approx(1.0)
+
+
+# ---------------------------------------------------------------------------
+# Cohen's kappa
+# ---------------------------------------------------------------------------
+
+
+def test_kappa_perfect() -> None:
+    labels = ["SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO", "SUPPORTED"]
+    assert cohen_kappa(labels, labels) == pytest.approx(1.0)
+
+
+def test_kappa_chance_level_is_near_zero() -> None:
+    # Both raters use the same marginal split but agree only at chance.
+    expected = ["SUPPORTED", "CONTRADICTED"] * 10
+    predicted = (["SUPPORTED", "CONTRADICTED"] * 5) + (["CONTRADICTED", "SUPPORTED"] * 5)
+    k = cohen_kappa(expected, predicted)
+    assert abs(k) < 0.25  # near chance
+
+
+def test_kappa_hand_computed() -> None:
+    # 4 items: 3 agree, 1 disagrees.
+    expected = ["SUPPORTED", "SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO"]
+    predicted = ["SUPPORTED", "SUPPORTED", "CONTRADICTED", "SUPPORTED"]
+    # p_o = 3/4 = 0.75
+    # marginals expected: SUP=2, CON=1, NEI=1 ; predicted: SUP=3, CON=1, NEI=0
+    # p_e = (2/4*3/4) + (1/4*1/4) + (1/4*0/4) = 0.375 + 0.0625 + 0 = 0.4375
+    # kappa = (0.75 - 0.4375) / (1 - 0.4375) = 0.3125 / 0.5625
+    assert cohen_kappa(expected, predicted) == pytest.approx(0.3125 / 0.5625)
+
+
+def test_kappa_empty() -> None:
+    assert cohen_kappa([], []) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Band checks
+# ---------------------------------------------------------------------------
+
+
+def test_in_band() -> None:
+    assert in_band(0.95, (0.9, 1.0))
+    assert in_band(0.9, (0.9, 1.0))  # inclusive
+    assert not in_band(0.8, (0.9, 1.0))
+
+
+def test_band_mae() -> None:
+    # score 0.6 vs midpoint 0.5 -> err 0.1 ; score 1.0 vs midpoint 0.95 -> err 0.05
+    mae = band_mae([0.6, 1.0], [(0.4, 0.6), (0.9, 1.0)])
+    assert mae == pytest.approx((0.1 + 0.05) / 2)
+
+
+# ---------------------------------------------------------------------------
+# Golden set integrity (catches typos / bad labels at author time)
+# ---------------------------------------------------------------------------
+
+
+def test_golden_claims_are_well_formed() -> None:
+    claims = load_golden_claims()
+    assert len(claims) >= 10, "golden claim set too small to be meaningful"
+    ids = [c.id for c in claims]
+    assert len(ids) == len(set(ids)), "duplicate golden claim ids"
+    valid = {"SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO"}
+    for c in claims:
+        assert c.expected in valid, f"{c.id} has invalid label {c.expected!r}"
+        assert c.claim.strip(), f"{c.id} has empty claim"
+        assert c.context and all(ctx.strip() for ctx in c.context), f"{c.id} bad context"
+
+
+def test_golden_claims_cover_all_three_verdicts() -> None:
+    claims = load_golden_claims()
+    labels = {c.expected for c in claims}
+    assert labels == {"SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO"}, (
+        "golden set must exercise every verdict class or per-class F1 is undefined"
+    )
+
+
+def test_golden_cases_bands_are_valid() -> None:
+    cases = load_golden_cases()
+    assert len(cases) >= 3
+    for case in cases:
+        low, high = case.expected_band
+        assert 0.0 <= low <= high <= 1.0, f"{case.id} has an invalid band"
+
+
+# ---------------------------------------------------------------------------
+# The harness itself, driven by a deterministic StubJudge
+# ---------------------------------------------------------------------------
+
+
+async def test_harness_perfect_judge() -> None:
+    golden = load_golden_claims()
+    perfect = StubJudge({c.claim: c.expected for c in golden})
+    report = await run_claim_agreement(perfect, golden)
+    assert report.n == len(golden)
+    assert report.accuracy == pytest.approx(1.0)
+    assert report.cohen_kappa == pytest.approx(1.0)
+    assert report.macro_f1 == pytest.approx(1.0)
+    assert report.disagreements == []
+
+
+async def test_harness_records_disagreements() -> None:
+    golden = load_golden_claims()
+    # Flip exactly one label so the judge disagrees on one item.
+    target = golden[0]
+    wrong = "CONTRADICTED" if target.expected != "CONTRADICTED" else "SUPPORTED"
+    lookup = {c.claim: c.expected for c in golden}
+    lookup[target.claim] = wrong
+
+    report = await run_claim_agreement(StubJudge(lookup), golden)
+    assert len(report.disagreements) == 1
+    d = report.disagreements[0]
+    assert d["id"] == target.id
+    assert d["expected"] == target.expected
+    assert d["predicted"] == wrong
+    assert report.accuracy == pytest.approx((len(golden) - 1) / len(golden))
+
+
+async def test_harness_snapshot_is_serialisable() -> None:
+    golden = load_golden_claims()
+    report = await run_claim_agreement(StubJudge({c.claim: c.expected for c in golden}), golden)
+    snap = report.to_snapshot()
+    assert snap["accuracy"] == 1.0
+    assert set(snap["per_class"]) == {"SUPPORTED", "CONTRADICTED", "NOT_ENOUGH_INFO"}
+    assert not math.isnan(snap["cohen_kappa"])

--- a/tests/meta/test_mutation_discrimination.py
+++ b/tests/meta/test_mutation_discrimination.py
@@ -1,0 +1,69 @@
+"""Live mutation (adversarial) discrimination test.
+
+A faithfulness evaluator that returns high scores for everything is useless even
+if it never crashes. This test takes a known-faithful answer, injects a
+fabricated claim, and asserts the score actually DROPS. It verifies the
+evaluator discriminates — the property unit tests with mocked judges cannot
+prove, because the mock decides the verdict, not the model.
+
+Gated behind `meta` and `RAGALIQ_RUN_META=1`; skipped without ANTHROPIC_API_KEY.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ragaliq.core.test_case import RAGTestCase
+from ragaliq.evaluators.faithfulness import FaithfulnessEvaluator
+from ragaliq.judges.base import LLMJudge
+
+pytestmark = pytest.mark.meta
+
+# A mutated answer must drop at least this far below the clean answer's score.
+MIN_SCORE_DROP = 0.20
+
+
+async def test_injected_hallucination_lowers_faithfulness(live_judge: LLMJudge) -> None:
+    context = [
+        "France is a country in Western Europe.",
+        "The capital city of France is Paris.",
+    ]
+    evaluator = FaithfulnessEvaluator(threshold=0.7)
+
+    clean = RAGTestCase(
+        id="clean",
+        name="Faithful answer",
+        query="What is the capital of France?",
+        context=context,
+        response="The capital of France is Paris.",
+    )
+    mutated = RAGTestCase(
+        id="mutated",
+        name="Answer with injected fabrication",
+        query="What is the capital of France?",
+        context=context,
+        response=(
+            "The capital of France is Paris, which has a population of 80 billion "
+            "people and was founded by Napoleon in 1620."
+        ),
+    )
+
+    clean_result = await evaluator.evaluate(clean, live_judge)
+    mutated_result = await evaluator.evaluate(mutated, live_judge)
+
+    drop = clean_result.score - mutated_result.score
+    print(
+        f"\nMutation discrimination: clean={clean_result.score:.3f} "
+        f"mutated={mutated_result.score:.3f} drop={drop:.3f}"
+    )
+    print(f"  clean reasoning:   {clean_result.reasoning}")
+    print(f"  mutated reasoning: {mutated_result.reasoning}")
+
+    assert clean_result.score >= 0.9, (
+        f"clean answer should score high, got {clean_result.score:.3f}"
+    )
+    assert drop >= MIN_SCORE_DROP, (
+        f"injected fabrications only dropped the score by {drop:.3f}; "
+        f"evaluator is not discriminating (expected >= {MIN_SCORE_DROP})"
+    )
+    assert not mutated_result.passed, "mutated answer should fail the 0.7 threshold"


### PR DESCRIPTION
## Summary

- upgrade the CI, docs, and release workflows to the latest stable major versions of their GitHub Actions
- pin the PyPI publishing action to its current stable release
- add offline evaluation demos, sample output, deterministic meta-evaluation helpers, and golden datasets
- keep Claude-backed meta tests explicitly opt-in while running deterministic meta metrics in CI and release validation

## Why

This keeps the repository's automation current and makes the evaluation examples and judge-quality checks reproducible without making paid API calls part of the default test suite.

## Validation

- `actionlint`
- `hatch run lint`
- `hatch run typecheck`
- focused mypy validation for the new demo and meta-test files
- `655 passed, 1 skipped, 2 deselected`
- paid Claude tests verified to remain disabled without `RAGALIQ_RUN_META=1`

## Impact

CI/CD configuration, tests, and examples only. No runtime dependency changes.