### PR TITLE
[DOCS #87] Add chore/ to branch-prefix and commit-type tables

### DIFF
--- a/.claude/CONSTANTS.md
+++ b/.claude/CONSTANTS.md
@@ -41,6 +41,7 @@ Format: `<prefix>/<issue>-<description>`
 | `[FIX]` | `fix/` |
 | `[REFACTOR]` | `refactor/` |
 | `[DOCS]` | `docs/` |
+| `[CHORE]` | `chore/` |
 | (none) | `feat/` |
 
 ## Commit Type Mapping
@@ -53,6 +54,7 @@ Inferred from branch prefix — used by `/ship` when building `[TYPE #N]` commit
 | `fix/`        | `FIX`       |
 | `refactor/`   | `REFACTOR`  |
 | `docs/`       | `DOCS`      |
+| `chore/`      | `CHORE`     |
 | (none)        | `FEAT`      |
 
 ## Issue Type Defaults


### PR DESCRIPTION
Closes #87

`chore/` had no row in the **Branch Naming** table or the **Commit Type Mapping** table in `.claude/CONSTANTS.md`. `ship.md` maps a branch prefix to a commit TYPE via that table, so `chore/` fell through to the `(none) → FEAT` default and every chore commit would have been labelled `FEAT`.

The `chore` GitHub label already exists (`.github/LABELS.md:20` — Maintenance / Dependencies, tooling, config updates), so the label side worked; only the branch/commit mapping was missing.

## Changes
- Branch Naming table: `[CHORE]` → `chore/`
- Commit Type Mapping table: `chore/` → `CHORE`

## Not changed
The **Issue Type Defaults** table (priority/size for `/start-work`) has no `[CHORE]` row either, so `[CHORE]` issues fall through to `(none) → Medium / M`. That is a sensible default rather than a mislabel, so it is left alone to keep this PR to the stated scope.

## Gates
```
hatch run lint       exit=0  All checks passed!
hatch run typecheck  exit=0  Success: no issues found in 36 source files
hatch run test       exit=0  655 passed, 1 skipped, 2 deselected
```

Lands first — it blocks correct labelling on all subsequent dependency and tooling work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)