### PR TITLE
[CHORE #89] Pin meta-eval baseline and derive drift tolerance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,6 @@ Thumbs.db
 
 # Stale root-level package artifacts (use src/ layout only)
 ragaliq/__pycache__/
+
+# Meta-eval run artefacts (the pinned baseline IS tracked; per-run latest is not)
+tests/meta/baselines/*_latest.json

--- a/tests/meta/baselines/judge_agreement_baseline.json
+++ b/tests/meta/baselines/judge_agreement_baseline.json
@@ -1,0 +1,27 @@
+{
+  "model": "claude-sonnet-4-6",
+  "n": 14,
+  "accuracy": 1.0,
+  "cohen_kappa": 1.0,
+  "macro_f1": 1.0,
+  "per_class": {
+    "SUPPORTED": {
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0,
+      "support": 6
+    },
+    "CONTRADICTED": {
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0,
+      "support": 4
+    },
+    "NOT_ENOUGH_INFO": {
+      "precision": 1.0,
+      "recall": 1.0,
+      "f1": 1.0,
+      "support": 4
+    }
+  }
+}

--- a/tests/meta/test_judge_agreement.py
+++ b/tests/meta/test_judge_agreement.py
@@ -30,15 +30,23 @@ from tests.meta.meta_metrics import (
     write_snapshot,
 )
 
-# Absolute floors for the very first run (no baseline yet). Conservative: a
-# usable three-way judge should clear these comfortably. Tighten as you learn
-# your judge's real numbers.
+# Absolute floors. Measured 2026-07-28 against claude-sonnet-4-6 over three
+# consecutive runs (see issue #89): accuracy, kappa and macro-F1 were all
+# exactly 1.000 every run, with zero disagreements across all 14 claims. The
+# floors below are therefore cleared with full headroom and are kept
+# deliberately loose — they catch a judge that breaks, not one that drifts.
 MIN_ACCURACY = 0.70
 MIN_KAPPA = 0.50  # 'moderate' agreement beyond chance
 MIN_MACRO_F1 = 0.65
 
 # How much macro-F1 may drop versus a pinned baseline before it's a regression.
-MACRO_F1_DRIFT_TOLERANCE = 0.10
+# Derived, not chosen: observed_spread over the three runs was 0.000, so
+# round(max(2 * 0.000, 0.05), 2) = 0.05.
+#
+# Caveat: with n=14 a single misclassification moves accuracy by 1/14 = 0.071,
+# so this tolerance sits below the metric's own resolution. The fix is more
+# golden claims, not a tighter constant — tracked in issue #90.
+MACRO_F1_DRIFT_TOLERANCE = 0.05
 
 pytestmark = pytest.mark.meta
 


### PR DESCRIPTION
Closes #89

Phases B and C. Three live runs against `claude-sonnet-4-6` on 2026-07-28 — the first time judge quality has existed as an observation rather than a set of unexercised constants.

## Measured

| Run | accuracy | kappa | macro-F1 |
|-----|----------|-------|----------|
| 1 | 1.0000 | 1.0000 | 1.0000 |
| 2 | 1.0000 | 1.0000 | 1.0000 |
| 3 | 1.0000 | 1.0000 | 1.0000 |

Zero disagreements across all 14 claims, every run. All three snapshots byte-identical (md5 `5b75d7790f7473aa37ed31d752c0496d`). Per-class P/R/F1 = 1.00 for SUPPORTED (n=6), CONTRADICTED (n=4), NOT_ENOUGH_INFO (n=4). Mutation discrimination: clean 1.000, mutated 0.250, drop 0.750 against a 0.7 threshold; K=1 clean, K=4 mutated.

Cost: 21 judge calls per run, **63 total**.

## Changes

- **Pin the baseline** — `judge_agreement_baseline.json` from the median run. `load_baseline()` no longer returns `None`, so the drift check at `test_judge_agreement.py:77-78` fires for the first time. This is what makes the anthropic bump in Phase J measurable.
- **`MACRO_F1_DRIFT_TOLERANCE` 0.10 → 0.05** — derived, not chosen: `round(max(2 × 0.000, 0.05), 2)`. The floor bound, since spread was zero.
- **Floors comment** replaced with the measured numbers and date. Floors themselves unchanged at 0.70 / 0.50 / 0.65 — cleared with full headroom.
- **`.gitignore`** — `tests/meta/baselines/*_latest.json`. The pinned baseline is tracked; per-run output never is.

## Known limitation

A perfect 1.000 with zero variance means the golden set is **saturated** — it detects breakage, not drift. With n=14 a single flip moves accuracy by 0.071, which is *above* the 0.05 tolerance, so the gate has no chance to warn before it fires. The fix is more claims, not a tighter constant. Tracked in #90; deliberately not addressed here.

## Gates

```
hatch run lint       exit=0  All checks passed!
hatch run typecheck  exit=0  Success: no issues found in 36 source files
hatch run test       exit=0  655 passed, 1 skipped, 2 deselected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)