### PR TITLE
[CHORE #92] Fail the meta gate when it cannot return a verdict

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ plugins = ["pydantic.mypy"]
 testpaths = ["tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "function"
-addopts = "-v --cov=ragaliq --cov-report=term-missing -m 'not meta'"
+addopts = "-v --strict-markers --cov=ragaliq --cov-report=term-missing -m 'not meta'"
 markers = [
     "meta: paid live judge-quality evaluation; requires explicit opt-in",
 ]

--- a/tests/meta/conftest.py
+++ b/tests/meta/conftest.py
@@ -27,14 +27,6 @@ if TYPE_CHECKING:
     from ragaliq.judges.base import LLMJudge
 
 
-def pytest_configure(config: pytest.Config) -> None:
-    """Register the `meta` marker for live judge-quality benchmarks."""
-    config.addinivalue_line(
-        "markers",
-        "meta: live judge meta-evaluation against the golden set (needs ANTHROPIC_API_KEY)",
-    )
-
-
 @pytest.fixture
 def golden_claims() -> list[GoldenClaim]:
     """The human-labelled claim-verdict golden set."""
@@ -49,11 +41,20 @@ def golden_cases() -> list[GoldenCase]:
 
 @pytest.fixture
 def live_judge() -> LLMJudge:
-    """A real ClaudeJudge. Skips the test cleanly if no API key is configured."""
+    """A real ClaudeJudge.
+
+    Skips when the paid tier was not requested. Fails — deliberately, not
+    skips — when it *was* requested but cannot run, so that "the gate could
+    not return a verdict" is never reported as success.
+    """
     if os.getenv("RAGALIQ_RUN_META") != "1":
         pytest.skip("set RAGALIQ_RUN_META=1 to enable paid meta-evaluation")
     if not os.getenv("ANTHROPIC_API_KEY"):
-        pytest.skip("ANTHROPIC_API_KEY not set; skipping live meta-evaluation")
+        pytest.fail(
+            "RAGALIQ_RUN_META=1 was set but ANTHROPIC_API_KEY is missing. "
+            "The gate cannot return a verdict, so it must not report success.",
+            pytrace=False,
+        )
     from ragaliq.judges.claude import ClaudeJudge
 
     return ClaudeJudge()


### PR DESCRIPTION
Closes #92

## The defect

`conftest.py` tested intent correctly — `RAGALIQ_RUN_META != "1"` → skip — but the next branch *also* skipped when the key was missing, after intent had already been affirmed. So "I asked for the gate and it could not run" exited 0, identically to "I did not ask for it."

Replaced only that branch with `pytest.fail(..., pytrace=False)`.

## Also in this PR

- `--strict-markers` added to `addopts`
- Duplicate `meta` marker registration deleted from `conftest.pytest_configure`; `pyproject.toml:161-163` is now the single registry

## Verified by running, not reading

| Command | exit | Note |
|---|---|---|
| `RAGALIQ_RUN_META=1`, no key | **1** | was 0; message: *"The gate cannot return a verdict, so it must not report success."* |
| `-m "not meta"` | **0** | 19 passed, 2 deselected |
| unregistered marker on a test | **2** | *"'definitely_not_registered' not found in `markers` configuration option"* |

## One correction to the spec

`-m nonexistent_marker` returns **exit 5** (`NO_TESTS_COLLECTED`), not a strict-markers error — and it does so with or without the flag. `--strict-markers` validates markers *applied to tests*, not marker *filter expressions* passed to `-m`. The guarantee it actually buys is the third row above, which is the one worth having: a typo'd `@pytest.mark.meta` now fails collection instead of silently never running.

Note this makes the single remaining registration load-bearing — with `--strict-markers` on, dropping `pyproject.toml:161-163` would break every meta test at collection rather than silently deselecting them.

## Gates

```
hatch run lint       exit=0  All checks passed!
hatch run typecheck  exit=0  Success: no issues found in 36 source files
hatch run test       exit=0  655 passed, 1 skipped, 2 deselected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)