### PR TITLE
[CHORE #94] Run the meta gate weekly in CI

### DIFF
--- a/.github/workflows/meta-eval.yml
+++ b/.github/workflows/meta-eval.yml
@@ -1,0 +1,103 @@
+name: Meta Evaluation
+
+# Live judge-quality benchmark. This job makes real, paid Anthropic API calls,
+# so it is deliberately NOT wired to push or pull_request — per-PR would bill
+# every push. Weekly plus manual dispatch only.
+#
+# What it gates: the agreement floors and the pinned macro-F1 baseline in
+# tests/meta/baselines/judge_agreement_baseline.json (see issue #89). A red run
+# means judge quality moved, not that the build broke.
+on:
+  schedule:
+    # 06:00 UTC every Monday.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+# Never run two paid evaluations at once.
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  meta-eval:
+    name: Judge agreement vs golden set
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7.0.0
+
+      - uses: actions/setup-python@v6.3.0
+        with:
+          python-version: "3.14"
+
+      - uses: astral-sh/setup-uv@v8.3.2
+        with:
+          enable-cache: true
+          cache-dependency-glob: "pylock.toml"
+
+      # Same install path as ci.yml: the gate must measure the locked
+      # dependency set, not a floating resolution.
+      - name: Install locked dependencies + project
+        run: |
+          uv venv --python 3.14
+          uv pip sync pylock.toml
+          uv pip install -e . --no-deps
+
+      - name: Run meta evaluation
+        env:
+          RAGALIQ_RUN_META: "1"
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: .venv/bin/pytest tests/meta/ -m meta --no-cov -v -s
+
+      # Runs on failure too — a regression is exactly when the numbers matter.
+      - name: Write agreement numbers to step summary
+        if: always()
+        run: |
+          SNAPSHOT=tests/meta/baselines/judge_agreement_latest.json
+
+          if [ ! -f "$SNAPSHOT" ]; then
+            echo "### Meta evaluation" >> "$GITHUB_STEP_SUMMARY"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "No snapshot produced — the run failed before judging completed." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+
+          .venv/bin/python - <<'PY' >> "$GITHUB_STEP_SUMMARY"
+          import json
+          import os
+
+          snap = json.load(open("tests/meta/baselines/judge_agreement_latest.json"))
+          base = None
+          if os.path.exists("tests/meta/baselines/judge_agreement_baseline.json"):
+              base = json.load(open("tests/meta/baselines/judge_agreement_baseline.json"))
+
+          print("### Meta evaluation")
+          print()
+          print(f"Model `{snap['model']}` — n={snap['n']}")
+          print()
+          print("| Metric | This run | Baseline | Delta |")
+          print("|--------|----------|----------|-------|")
+          for key, label in (
+              ("accuracy", "accuracy"),
+              ("cohen_kappa", "Cohen's kappa"),
+              ("macro_f1", "macro-F1"),
+          ):
+              cur = snap[key]
+              if base is None:
+                  print(f"| {label} | {cur:.4f} | — | — |")
+              else:
+                  ref = base[key]
+                  print(f"| {label} | {cur:.4f} | {ref:.4f} | {cur - ref:+.4f} |")
+
+          print()
+          print("| Class | P | R | F1 | support |")
+          print("|-------|---|---|-----|---------|")
+          for name, m in snap["per_class"].items():
+              print(
+                  f"| {name} | {m['precision']:.2f} | {m['recall']:.2f} "
+                  f"| {m['f1']:.2f} | {m['support']} |"
+              )
+          PY


### PR DESCRIPTION
Closes #94

The meta-evaluation suite has never executed in CI. `RAGALIQ_RUN_META` appeared in zero workflows and no job wired `ANTHROPIC_API_KEY`, so the agreement floors and the baseline pinned in #89 gated nothing automatically.

## Design

- **Weekly cron (Mon 06:00 UTC) + `workflow_dispatch`. Never `push`/`pull_request`** — per-PR would bill paid judge calls on every push. ~21 calls per run.
- **Installs from `pylock.toml`** exactly as `ci.yml:35-37` does, so the gate measures the locked dependency set rather than a floating resolution.
- **`concurrency` with `cancel-in-progress: false`** — never two paid evaluations at once, and never kill one mid-flight after it has already spent.
- **`timeout-minutes: 20`**, **`permissions: contents: read`**.
- **Step summary runs `if: always()`** — a regression is exactly when you want the numbers.

## Secret

`gh secret list` confirms **`ANTHROPIC_API_KEY` already exists** (added 2026-02-27). No action needed; this PR is not draft.

## Step summary, verified locally against the real snapshots

```
### Meta evaluation

Model `claude-sonnet-4-6` — n=14

| Metric | This run | Baseline | Delta |
|--------|----------|----------|-------|
| accuracy | 1.0000 | 1.0000 | +0.0000 |
| Cohen's kappa | 1.0000 | 1.0000 | +0.0000 |
| macro-F1 | 1.0000 | 1.0000 | +0.0000 |
```

Plus a per-class P/R/F1 table. I extracted the embedded script and executed it against the actual baseline files rather than eyeballing it — worth noting because my first syntax check passed against an empty extraction and was a false positive.

## The failure mode, named

**A red run here will not be noticed by default.** It blocks nobody's PR and appears on no one's checks list. GitHub emails only the last committer of the workflow file on a scheduled-run failure, and that notification is easy to filter away. A weekly job that fails silently for a month is worse than no job, because it reads as "the gate is green."

This PR does **not** solve that — it is genuinely unsolved here. The realistic fixes, none of which belong in this PR:
1. `actions/github-script` to open an issue on failure, so a regression lands on the board rather than in an inbox.
2. A Slack/webhook notification step.
3. A badge in the README, which at least makes staleness visible to anyone reading the repo.

Option 1 is the one I would pick — it puts a red run somewhere that already gets triaged. Worth a follow-up issue.

## Gates

```
hatch run lint       exit=0  All checks passed!
hatch run typecheck  exit=0  Success: no issues found in 36 source files
hatch run test       exit=0  655 passed, 1 skipped, 2 deselected
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)