### PR TITLE
[CHORE #96] Run the five golden cases through the live runner

### DIFF
--- a/tests/meta/test_golden_cases_live.py
+++ b/tests/meta/test_golden_cases_live.py
@@ -1,0 +1,82 @@
+"""Tier-0 live smoke: the five golden cases through the real runner.
+
+Every other paid test bypasses `RagaliQ`. `test_judge_agreement` calls
+`judge.verify_claim` directly and `test_mutation_discrimination` instantiates
+`FaithfulnessEvaluator` itself, so the runner path — evaluator registry,
+concurrency semaphores, result aggregation, status derivation — has no live
+coverage at all. That is the path an SDK bump actually threatens.
+
+This test is cheap and end to end: it evaluates the five `GoldenCase` triples
+through `RagaliQ` and asserts each faithfulness score lands inside its
+human-labelled band.
+
+Gated behind `meta` and `RAGALIQ_RUN_META=1`; fails (does not skip) if the key
+is missing, per the `live_judge` fixture.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from ragaliq.core.runner import RagaliQ
+from ragaliq.core.test_case import EvalStatus, RAGTestCase
+
+if TYPE_CHECKING:
+    from ragaliq.judges.base import LLMJudge
+    from tests.meta.meta_metrics import GoldenCase
+
+pytestmark = pytest.mark.meta
+
+
+async def test_golden_cases_land_in_expected_bands(
+    live_judge: LLMJudge, golden_cases: list[GoldenCase]
+) -> None:
+    """Every golden case scores inside its band when run through `RagaliQ`."""
+    runner = RagaliQ(judge=live_judge)
+
+    test_cases = [
+        RAGTestCase(
+            id=case.id,
+            name=case.note or case.id,
+            query=case.query,
+            context=case.context,
+            response=case.response,
+        )
+        for case in golden_cases
+    ]
+
+    # evaluate_batch_async, not the sync evaluate(): we are already inside an
+    # event loop (asyncio_mode=auto), and the sync wrapper cannot nest.
+    results = await runner.evaluate_batch_async(test_cases)
+
+    assert len(results) == len(golden_cases)
+
+    out_of_band: list[str] = []
+
+    for case, result in zip(golden_cases, results, strict=True):
+        # Status first. An evaluator that raises is recorded with a fabricated
+        # score of 0.0 (runner.py:171-180) and status ERROR, which would slide
+        # past a bare score check for the low-band cases.
+        assert result.status is not EvalStatus.ERROR, (
+            f"{case.id}: evaluator errored, score is fabricated. details={result.details}"
+        )
+
+        score = result.get_score("faithfulness")
+        assert score is not None, f"{case.id}: no faithfulness score in {result.scores}"
+
+        low, high = case.expected_band
+        print(
+            f"  {case.id:<28} score={score:.3f} band=[{low:.2f}, {high:.2f}] "
+            f"status={result.status.value} tokens={result.judge_tokens_used}"
+        )
+        if not low <= score <= high:
+            out_of_band.append(
+                f"{case.id}: {score:.3f} outside [{low:.2f}, {high:.2f}] — "
+                f"{result.details.get('faithfulness', {}).get('reasoning', '')}"
+            )
+
+    # Report every failure at once; one run costs real money, so a single
+    # assertion per case would hide the rest behind the first failure.
+    assert not out_of_band, "faithfulness scores outside their bands:\n" + "\n".join(out_of_band)


### PR DESCRIPTION
Closes #96

Tier-0 smoke that was missing: cheap, end to end, and it exercises the runner path an SDK bump actually threatens.

## Why it matters

No paid test touched `RagaliQ` at all. `test_judge_agreement` calls `judge.verify_claim` directly; `test_mutation_discrimination.py:31` instantiates `FaithfulnessEvaluator` and calls `.evaluate()` at `:51-52`. So the evaluator registry, the concurrency semaphores, result aggregation and status derivation had **zero** live coverage — while the five `GoldenCase` triples sat unused by anything but a data-validation test.

## Constraints honoured

- **Same fixture, no second file** — reads `golden_cases` from the existing `conftest.py:44-47`.
- **`evaluate_batch_async`, not `evaluate()`** —  means we are already inside a loop, and the sync wrapper cannot nest.
- **Canonical status first, never a bare score.** `runner.py:171-180` fabricates `score=0.0` and sets status `ERROR` when an evaluator raises. A raw band check would pass that as "0.0, in band" for `fully_hallucinated` (band [0.0, 0.25]) — a broken judge reading as a green test. The assert on `status is not EvalStatus.ERROR` comes first.
- **All failures reported together** — one run costs money, so a per-case assert would hide every failure behind the first.

## Verified free, before spending

Ran the same runner path with a stub judge (no API calls):

```
evaluators configured: ['faithfulness', 'relevance']
results: 5 (expected 5)
  fully_faithful               status=passed  faithfulness=1.0 keys=['faithfulness', 'relevance']
  ... (5/5)
MECHANICS OK — scores dict keyed 'faithfulness', no ERROR status
```

That confirms `RagaliQ(judge=<LLMJudge>)` accepts the fixture instance, the batch call returns 5 results, and `get_score("faithfulness")` resolves — so the only unknown left on a paid run is the scores themselves.

## Cost

Confirmed the default pair is `['faithfulness', 'relevance']`, and `relevance.py:33` is a single call with no fan-out — so **K+2 per case**, as specified. Estimated **~21 added calls** for the five cases (K of 1–3 each), roughly doubling a full `-m meta` run from ~21 to ~42.

**Estimated, not measured** — I have no API key in this environment, so the live numbers are pending. The first weekly `meta-eval.yml` run or a manual dispatch will produce them.

## Gates

```
hatch run lint       exit=0  All checks passed!  (after hatch run format fixed import order)
hatch run typecheck  exit=0  Success: no issues found in 36 source files
hatch run test       exit=0  655 passed, 1 skipped, 3 deselected
```

Deselected count moved 2 → 3, confirming the new test registers as `meta` and stays out of the free tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)