### PR TITLE
[CHORE #100] Slice 1: bump five pinned GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@v8.3.2
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "pylock.toml"
@@ -43,13 +43,13 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@v8.3.2
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "pylock.toml"
@@ -71,13 +71,13 @@ jobs:
       matrix:
         python-version: ["3.14"]
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
 
-      - uses: astral-sh/setup-uv@v8.3.2
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "pylock.toml"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,9 +23,9 @@ jobs:
     name: Build Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14"
           cache: "pip"

--- a/.github/workflows/meta-eval.yml
+++ b/.github/workflows/meta-eval.yml
@@ -27,13 +27,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14"
 
-      - uses: astral-sh/setup-uv@v8.3.2
+      - uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
           cache-dependency-glob: "pylock.toml"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ jobs:
     name: Validate Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14"
           cache: "pip"
@@ -57,9 +57,9 @@ jobs:
     needs: [validate]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
-      - uses: actions/setup-python@v6.3.0
+      - uses: actions/setup-python@v7.0.0
         with:
           python-version: "3.14"
           cache: "pip"
@@ -115,7 +115,7 @@ jobs:
           path: dist/
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.1
 
   # ──────────────────────────────────────────────────────────────────────
   # Job 4: Build and Push Docker Image — to GitHub Container Registry (GHCR).
@@ -138,13 +138,13 @@ jobs:
       packages: write  # REQUIRED to push to GHCR
 
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4.2.0
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4.4.0
+        uses: docker/login-action@v4.5.1
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -183,7 +183,7 @@ jobs:
       contents: write  # REQUIRED to create releases and upload assets
 
     steps:
-      - uses: actions/checkout@v7.0.0
+      - uses: actions/checkout@v7.0.1
         with:
           fetch-depth: 0  # Full history needed for release notes generation
 


### PR DESCRIPTION
Closes #100

| Action | From | To | Class |
|---|---|---|---|
| `actions/setup-python` | v6.3.0 | **v7.0.0** | major |
| `astral-sh/setup-uv` | v8.3.2 | **v9.0.0** | major |
| `docker/login-action` | v4.4.0 | v4.5.1 | minor |
| `actions/checkout` | v7.0.0 | v7.0.1 | patch |
| `pypa/gh-action-pypi-publish` | v1.14.0 | v1.14.1 | patch |

## Both majors, read before editing

**`setup-python@v7`** — removes the **`pip-install` input** and migrates to ESM. We never used `pip-install`; `grep -rn 'pip-install' .github/` returns nothing. The inputs we do use — `python-version` (7 sites) and `cache: "pip"` (3 sites) — are unchanged. No rename affects us.

**`setup-uv@v9`** — one breaking change: **`prune-cache` default flips `true` → `false`**, deliberately, to reduce load on PyPI infrastructure. We never set it, so we inherit the new default. Consequence is larger GitHub Actions cache entries, not a behaviour change; `enable-cache: true` and `cache-dependency-glob: "pylock.toml"` are unaffected. Left at the new default rather than pinning `prune-cache: true`, since the upstream reasoning applies to us too — worth revisiting only if cache storage becomes a cost.

## Verification

YAML re-parsed for all four workflows. Gates green. `verify_release.py` still reports the Python atom agreeing across 14 sites — worth checking here specifically, because this PR edits seven of those sites.

```
hatch run lint       exit=0
hatch run typecheck  exit=0
hatch run test       exit=0  655 passed, 1 skipped, 3 deselected
Python atom agrees across 14 sites: PASS (3.14)
```

Real-run verification follows once this PR's own checks complete — CI here exercises `checkout`, `setup-python@v7` and `setup-uv@v9` directly, and I will dispatch `meta-eval.yml` after merge.

**`release.yml` cannot be exercised without pushing a tag**, so `gh-action-pypi-publish`, `login-action`, and the docker steps are **not verified by this PR** — they are only verified at the next real release. Stating that rather than implying the diff is proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)