### PR TITLE
[FIX #102] Gate golden cases on a granularity-invariant class, not a band

### DIFF
--- a/tests/meta/golden/faithfulness_cases.yaml
+++ b/tests/meta/golden/faithfulness_cases.yaml
@@ -2,9 +2,17 @@
 #
 # Unlike claim_verdicts.yaml (which labels the judge's atomic decision), this set
 # labels the FaithfulnessEvaluator's emitted score on a full (query, context,
-# response) tuple. Because claim extraction count varies slightly run to run, the
-# human label is a BAND, not an exact value. The meta-eval asserts the score lands
-# inside the band and reports MAE against the band midpoint as a continuous signal.
+# response) tuple.
+#
+# The GATE is `expected_class`, not `expected_band`. A band encodes an assumed
+# claim count: [0.4, 0.7] holds only if the extractor decomposes the response the
+# way the fixture author did, and it does not — see issue #102, where K=3 against
+# an assumed 2 put a correct judgement at 0.333, outside the band. The three
+# classes hold for every K, since 0/K and K/K are exact for all K.
+#
+# `expected_band` is retained as a recorded diagnostic for spotting score drift.
+# It is no longer asserted on. Notes describe semantic content only, never a
+# claim count.
 
 cases:
   - id: fully_faithful
@@ -14,7 +22,8 @@ cases:
       - "The capital city of France is Paris."
     response: "The capital of France is Paris."
     expected_band: [0.9, 1.0]
-    note: "Single claim, fully grounded."
+    expected_class: FULLY_FAITHFUL
+    note: "Every claim in the response is grounded in the context."
 
   - id: one_hallucinated_of_two
     query: "Tell me about Paris."
@@ -23,7 +32,12 @@ cases:
       - "Paris sits on the Seine river."
     response: "Paris is the capital of France and was founded by Julius Caesar in 50 BC."
     expected_band: [0.4, 0.7]
-    note: "One supported claim (capital), one fabricated (founding) — roughly half."
+    expected_class: PARTIALLY_FAITHFUL
+    note: >-
+      The capital assertion is grounded; the founding attribution (agent and
+      date) is absent from the context. Deliberately says nothing about how many
+      atomic claims that decomposes into — the extractor may treat the agent and
+      the date as one claim or two, and both readings are partial.
 
   - id: fully_hallucinated
     query: "What is the boiling point of water?"
@@ -31,7 +45,8 @@ cases:
       - "Water is a chemical compound with the formula H2O."
     response: "Water boils at 350 degrees and is primarily composed of helium."
     expected_band: [0.0, 0.25]
-    note: "No claim is supported by the context."
+    expected_class: FULLY_HALLUCINATED
+    note: "No claim in the response is supported by the context."
 
   - id: faithful_multi_claim
     query: "Describe the solar system's inner planets."
@@ -41,7 +56,8 @@ cases:
       - "Earth is the third planet from the Sun."
     response: "Mercury is closest to the Sun, Venus is the hottest planet, and Earth is third from the Sun."
     expected_band: [0.9, 1.0]
-    note: "Three claims, all grounded."
+    expected_class: FULLY_FAITHFUL
+    note: "Every claim in the response is grounded in the context."
 
   - id: mostly_faithful_one_drift
     query: "What do we know about the pancreas?"
@@ -50,4 +66,7 @@ cases:
       - "It plays a role in digestion."
     response: "The pancreas sits behind the stomach, aids digestion, and is the largest organ in the body."
     expected_band: [0.55, 0.8]
-    note: "Two grounded claims, one unsupported ('largest organ')."
+    expected_class: PARTIALLY_FAITHFUL
+    note: >-
+      Location and digestive role are grounded; 'largest organ in the body' is
+      not in the context and is also false.

--- a/tests/meta/meta_metrics.py
+++ b/tests/meta/meta_metrics.py
@@ -50,15 +50,31 @@ class GoldenClaim:
     note: str = ""
 
 
+# Granularity-invariant labels for a case-level faithfulness outcome.
+#
+# A score band silently encodes an assumed claim count: [0.4, 0.7] only holds
+# if the extractor splits the response the way the fixture author did. It does
+# not (see issue #102 — K=3 where the fixture assumed 2). These three classes
+# hold for every K, because 0/K and K/K are exact for all K and anything
+# strictly between them is partial by definition.
+FAITHFULNESS_CLASSES = frozenset({"FULLY_FAITHFUL", "PARTIALLY_FAITHFUL", "FULLY_HALLUCINATED"})
+
+
 @dataclass(frozen=True)
 class GoldenCase:
-    """A human-labelled full RAG case with an expected faithfulness score band."""
+    """A human-labelled full RAG case.
+
+    `expected_class` is the gate: it survives a change in claim granularity.
+    `expected_band` is retained as a recorded diagnostic — useful for spotting
+    drift in the score, but no longer asserted on.
+    """
 
     id: str
     query: str
     context: list[str]
     response: str
     expected_band: tuple[float, float]
+    expected_class: str
     note: str = ""
 
 
@@ -157,6 +173,7 @@ def load_golden_cases(path: Path | None = None) -> list[GoldenCase]:
             context=list(item["context"]),
             response=item["response"],
             expected_band=(float(item["expected_band"][0]), float(item["expected_band"][1])),
+            expected_class=item["expected_class"],
             note=item.get("note", ""),
         )
         for item in raw["cases"]

--- a/tests/meta/test_golden_cases_live.py
+++ b/tests/meta/test_golden_cases_live.py
@@ -6,9 +6,11 @@ Every other paid test bypasses `RagaliQ`. `test_judge_agreement` calls
 concurrency semaphores, result aggregation, status derivation — has no live
 coverage at all. That is the path an SDK bump actually threatens.
 
-This test is cheap and end to end: it evaluates the five `GoldenCase` triples
-through `RagaliQ` and asserts each faithfulness score lands inside its
-human-labelled band.
+The gate is `expected_class`, not `expected_band`. A band assumes a claim
+count: issue #102 saw K=3 where the fixture assumed 2, putting a correct
+judgement at 0.333 and outside [0.40, 0.70]. The class assertions hold for
+every K, because 0/K and K/K are exact for all K. The band is still recorded
+in the snapshot as a drift diagnostic.
 
 Gated behind `meta` and `RAGALIQ_RUN_META=1`; fails (does not skip) if the key
 is missing, per the `live_judge` fixture.
@@ -16,7 +18,9 @@ is missing, per the `live_judge` fixture.
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -29,11 +33,26 @@ if TYPE_CHECKING:
 
 pytestmark = pytest.mark.meta
 
+_SNAPSHOT = Path(__file__).parent / "baselines" / "golden_cases_latest.json"
 
-async def test_golden_cases_land_in_expected_bands(
+
+def _claim_stats(details: dict[str, Any]) -> tuple[int | None, int | None]:
+    """Pull (K, supported) out of the faithfulness evaluator's raw payload.
+
+    `FaithfulnessEvaluator` records `total_claims` and `supported_claims` in
+    `raw_response`, which the runner surfaces under details[...]["raw"]. Read
+    the structured values — the reasoning string carries the same numbers in
+    prose, but parsing prose to recover a number the evaluator already
+    published is a defect waiting to happen.
+    """
+    raw = details.get("faithfulness", {}).get("raw") or {}
+    return raw.get("total_claims"), raw.get("supported_claims")
+
+
+async def test_golden_cases_match_expected_class(
     live_judge: LLMJudge, golden_cases: list[GoldenCase]
 ) -> None:
-    """Every golden case scores inside its band when run through `RagaliQ`."""
+    """Every golden case lands in its expected faithfulness class."""
     runner = RagaliQ(judge=live_judge)
 
     test_cases = [
@@ -53,12 +72,13 @@ async def test_golden_cases_land_in_expected_bands(
 
     assert len(results) == len(golden_cases)
 
-    out_of_band: list[str] = []
+    failures: list[str] = []
+    snapshot: list[dict[str, Any]] = []
 
     for case, result in zip(golden_cases, results, strict=True):
         # Status first. An evaluator that raises is recorded with a fabricated
-        # score of 0.0 (runner.py:171-180) and status ERROR, which would slide
-        # past a bare score check for the low-band cases.
+        # score of 0.0 and status ERROR, which would slide past a
+        # FULLY_HALLUCINATED assertion as a false pass.
         assert result.status is not EvalStatus.ERROR, (
             f"{case.id}: evaluator errored, score is fabricated. details={result.details}"
         )
@@ -66,17 +86,46 @@ async def test_golden_cases_land_in_expected_bands(
         score = result.get_score("faithfulness")
         assert score is not None, f"{case.id}: no faithfulness score in {result.scores}"
 
+        k, supported = _claim_stats(result.details)
         low, high = case.expected_band
-        print(
-            f"  {case.id:<28} score={score:.3f} band=[{low:.2f}, {high:.2f}] "
-            f"status={result.status.value} tokens={result.judge_tokens_used}"
+
+        snapshot.append(
+            {
+                "id": case.id,
+                "expected_class": case.expected_class,
+                "score": round(score, 4),
+                "k": k,
+                "supported": supported,
+                "recorded_band": [low, high],
+                "in_recorded_band": low <= score <= high,
+            }
         )
-        if not low <= score <= high:
-            out_of_band.append(
-                f"{case.id}: {score:.3f} outside [{low:.2f}, {high:.2f}] — "
+
+        print(
+            f"  {case.id:<28} score={score:.3f} K={k} supported={supported} "
+            f"class={case.expected_class} band=[{low:.2f}, {high:.2f}]"
+        )
+
+        # Exact equality at the extremes: 0/K and K/K are exact for every K, so
+        # a tolerance here would only mask a verifier defect.
+        if case.expected_class == "FULLY_FAITHFUL":
+            ok = score == 1.0
+        elif case.expected_class == "FULLY_HALLUCINATED":
+            ok = score == 0.0
+        else:
+            ok = 0.0 < score < 1.0
+
+        if not ok:
+            failures.append(
+                f"{case.id}: expected_class={case.expected_class} but score={score:.3f} "
+                f"(K={k}, supported={supported}, recorded band=[{low:.2f}, {high:.2f}]) — "
                 f"{result.details.get('faithfulness', {}).get('reasoning', '')}"
             )
 
-    # Report every failure at once; one run costs real money, so a single
-    # assertion per case would hide the rest behind the first failure.
-    assert not out_of_band, "faithfulness scores outside their bands:\n" + "\n".join(out_of_band)
+    _SNAPSHOT.parent.mkdir(parents=True, exist_ok=True)
+    _SNAPSHOT.write_text(json.dumps(snapshot, indent=2), encoding="utf-8")
+    print(f"  snapshot -> {_SNAPSHOT}")
+
+    # Report every failure at once; one run costs real money, so a per-case
+    # assert would hide the rest behind the first.
+    assert not failures, "golden cases outside their expected class:\n" + "\n".join(failures)

--- a/tests/meta/test_meta_metrics.py
+++ b/tests/meta/test_meta_metrics.py
@@ -22,6 +22,7 @@ from ragaliq.judges.base import (
     LLMJudge,
 )
 from tests.meta.meta_metrics import (
+    FAITHFULNESS_CLASSES,
     accuracy,
     band_mae,
     build_confusion,
@@ -220,6 +221,38 @@ def test_golden_cases_bands_are_valid() -> None:
     for case in cases:
         low, high = case.expected_band
         assert 0.0 <= low <= high <= 1.0, f"{case.id} has an invalid band"
+
+
+def test_golden_cases_classes_are_valid() -> None:
+    """Every case carries a known granularity-invariant class.
+
+    `expected_class` is what the live tier-0 test gates on, so an unrecognised
+    value must fail here — cheaply, offline — rather than during a paid run.
+    """
+    cases = load_golden_cases()
+    for case in cases:
+        assert case.expected_class in FAITHFULNESS_CLASSES, (
+            f"{case.id} has unknown expected_class {case.expected_class!r}; "
+            f"expected one of {sorted(FAITHFULNESS_CLASSES)}"
+        )
+
+
+def test_golden_cases_bands_agree_with_classes() -> None:
+    """The recorded band must not contradict the class it accompanies.
+
+    The band is a diagnostic, not a gate, but a band that disagrees with its
+    class means one of the two is wrong and the fixture is lying either way.
+    """
+    for case in load_golden_cases():
+        low, high = case.expected_band
+        if case.expected_class == "FULLY_FAITHFUL":
+            assert high == 1.0, f"{case.id}: FULLY_FAITHFUL band must reach 1.0"
+        elif case.expected_class == "FULLY_HALLUCINATED":
+            assert low == 0.0, f"{case.id}: FULLY_HALLUCINATED band must reach 0.0"
+        else:
+            assert low > 0.0 and high < 1.0, (
+                f"{case.id}: PARTIALLY_FAITHFUL band must exclude both extremes"
+            )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #102

## What happened

Run [30330568633](https://github.com/dariero/RagaliQ/actions/runs/30330568633): `one_hallucinated_of_two` scored **0.333** against band [0.40, 0.70]. In the same run agreement was **1.000 / 1.000 / 1.000**, identical to the baseline pinned in #89, and mutation drop was unchanged at 0.750.

**The judge did not regress.** The extractor returned **K=3** where the fixture's note assumed K=2 — it splits *"founded by Julius Caesar in 50 BC"* into agent and date, which is defensible atomicity. 1/3 = 0.333.

## Why not widen the band

Widening to [0.30, 0.70] turns the suite green and leaves the defect untouched: **a band in score-space silently encodes an assumption about claim granularity.** Any reworded response whose fabrication decomposes differently drifts out again — and the next failure looks like a judge regression when it is not. Rewriting the `response` text was also rejected: it hides the extractor's real behaviour behind a fixture tuned to avoid it.

## The fix

`expected_class` becomes the gate:

| expected_class | assertion | why exact |
|---|---|---|
| FULLY_FAITHFUL | `score == 1.0` | K/K is exact for every K |
| FULLY_HALLUCINATED | `score == 0.0` | 0/K is exact for every K |
| PARTIALLY_FAITHFUL | `0.0 < score < 1.0` | true for any partial split |

No tolerance at the extremes — one there would only mask a verifier defect.

`expected_band` is kept as a **recorded diagnostic** for spotting score drift, no longer asserted on.

## Also

- Two offline validators: `test_golden_cases_classes_are_valid` (membership) and `test_golden_cases_bands_agree_with_classes` (a band that contradicts its class means one of them is wrong). Both free — an unknown class now fails offline rather than during a paid run.
- `one_hallucinated_of_two`'s note rewritten: it asserted a claim count the fixture does not test. It now describes semantic content and explicitly declines to commit to a K.
- Snapshot `tests/meta/baselines/golden_cases_latest.json` records score, K, supported and band per case. Confirmed ignored by the Phase B rule (`.gitignore:116`).

## One correction to the brief

The brief suggested reusing how the mutation test reports K. That path is a **reasoning string** — it prints `clean_result.reasoning` (*"All 1 claims are supported..."*). `FaithfulnessEvaluator` already publishes `total_claims` and `supported_claims` in `raw_response`, surfaced by the runner at `details[...]["raw"]`. I read those instead; parsing prose to recover a number the evaluator already publishes would be a defect waiting to happen.

## Verification

```
hatch run pytest tests/meta/ -m "not meta"   21 passed, 3 deselected   (was 19; +2 validators)
hatch run lint       exit=0  All checks passed!
hatch run typecheck  exit=0  Success: no issues found in 36 source files
hatch run test       exit=0  657 passed, 1 skipped, 3 deselected
```

Replayed the new assertions against the five scores already measured — all five pass:

```
fully_faithful             1.000  FULLY_FAITHFUL      -> PASS
one_hallucinated_of_two    0.333  PARTIALLY_FAITHFUL  -> PASS
fully_hallucinated         0.000  FULLY_HALLUCINATED  -> PASS
faithful_multi_claim       1.000  FULLY_FAITHFUL      -> PASS
mostly_faithful_one_drift  0.667  PARTIALLY_FAITHFUL  -> PASS
```

The paid confirmation run is pending — see the PR thread.

Threshold-margin finding filed separately as **#103**: `mostly_faithful_one_drift` sits 0.033 from the 0.7 gate, and 2/3 vs 3/4 flips it. Not changed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)