### PR TITLE
[CHORE #110] Slice 4: anthropic 0.116 -> 0.120

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     hooks:
       - id: mypy
         additional_dependencies:
-          - anthropic>=0.116
+          - anthropic>=0.120
           - jinja2>=3.1
           - pydantic>=2.13
           - pytest>=9.1

--- a/pylock.toml
+++ b/pylock.toml
@@ -18,9 +18,9 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5e
 
 [[packages]]
 name = "anthropic"
-version = "0.116.0"
-sdist = { url = "https://files.pythonhosted.org/packages/66/a2/d31f14e28d49bae983a3634e38dfb4b31c50110b5e403596c5c6a20b23f8/anthropic-0.116.0.tar.gz", upload-time = 2026-07-02T19:08:10Z, size = 949149, hashes = { sha256 = "5fc248fbb9fe03ef686f8a774f81586bca31a043260aab88b387ea3660f4a396" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/c7/dd/2a1e81cf1b163acc340afc4ec74ed1d86f5eed1a809fabdeed3e0997b346/anthropic-0.116.0-py3-none-any.whl", upload-time = 2026-07-02T19:08:08Z, size = 956896, hashes = { sha256 = "6c0a7698e8d652455da3499978279bb2588c7264d0a35be3666009a4258c8256" } }]
+version = "0.120.0"
+sdist = { url = "https://files.pythonhosted.org/packages/92/5c/3331da4fc009d448008a50c78d86cc929e8c937cd1442245ce3f80561c4e/anthropic-0.120.0.tar.gz", upload-time = 2026-07-24T16:32:52Z, size = 1008042, hashes = { sha256 = "6ba6007dc9b00365b20f6101a6618f5196ac1ceef81512e4b5cc0e7436d4975d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/1b/8a/8522bdf809e1f95f0d9c936540987a3f6afba01d2921a2bf488dedf836a8/anthropic-0.120.0-py3-none-any.whl", upload-time = 2026-07-24T16:32:50Z, size = 1022602, hashes = { sha256 = "591bd531563ec7b63a1e138f5c11f14cb94edda99623b349c2ce2ece8e08b8a5" } }]
 
 [[packages]]
 name = "anyio"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "anthropic>=0.116",
+    "anthropic>=0.120",
     "pydantic>=2.13",
     "typer>=0.26",
     "rich>=15",


### PR DESCRIPTION
Closes #110

Lock diff verified before committing — **exactly one package moved**:
```
anthropic: 0.116.0 -> 0.120.0
TOTAL CHANGED: 1
```

Three sites move together: runtime floor `pyproject.toml:48`, the `mirrors-mypy` `additional_dependencies` pin `.pre-commit-config.yaml:14` (a fifth anthropic declaration — if it lags, mypy types against a different SDK than the code imports), and the lock.

## Paid verification — [run 30333368525](https://github.com/dariero/RagaliQ/actions/runs/30333368525), success, 3 passed

**The drift check fired for the first time** (baseline pinned in #89):

| metric | this run | baseline | delta | tolerance |
|---|---|---|---|---|
| accuracy | 1.000 | 1.000 | +0.000 | — |
| Cohen's kappa | 1.000 | 1.000 | +0.000 | — |
| macro-F1 | 1.000 | 1.000 | **+0.000** | 0.05 |

Mutation discrimination: clean 1.000, mutated 0.250, **drop 0.750** — unchanged.

Golden cases, all five, **K unchanged at (1, 3, 2, 3, 3)**:

| case | score | K | supported | class |
|---|---|---|---|---|
| fully_faithful | 1.000 | 1 | 1 | FULLY_FAITHFUL |
| one_hallucinated_of_two | 0.333 | 3 | 1 | PARTIALLY_FAITHFUL |
| fully_hallucinated | 0.000 | 2 | 0 | FULLY_HALLUCINATED |
| faithful_multi_claim | 1.000 | 3 | 3 | FULLY_FAITHFUL |
| mostly_faithful_one_drift | 0.667 | 3 | 2 | PARTIALLY_FAITHFUL |

**43 judge calls** — 14 agreement + 7 mutation + 22 golden (K+2 each), matching the pre-authorised estimate exactly.

Env pruned before gating so the suite ran against 0.120.0 rather than a cached 0.116.0 — the stale-env trap #106 called out.

## Gates
```
lint exit=0   typecheck exit=0 (37 files)   test exit=0 (657 passed)   consistency exit=0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)