### PR TITLE
[CHORE #115] Drop the hollow openai extra and de-version the error strings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-openai = ["openai>=2.45"]
 docs = [
     "mkdocs-material>=9.7",
 ]

--- a/src/ragaliq/core/runner.py
+++ b/src/ragaliq/core/runner.py
@@ -99,9 +99,9 @@ class RagaliQ:
                 )
             case "openai":
                 raise NotImplementedError(
-                    "The OpenAI judge is not yet available in v0.1.0. "
+                    "The OpenAI judge is not implemented. "
                     "Use judge='claude' with an ANTHROPIC_API_KEY instead. "
-                    "Track OpenAI support at: https://github.com/dariero/RagaliQ/issues"
+                    "Track OpenAI support at: https://github.com/dariero/RagaliQ/issues/114"
                 )
             case _:
                 raise ValueError(f"Unknown judge type: {self.judge_type}")

--- a/src/ragaliq/integrations/pytest_plugin.py
+++ b/src/ragaliq/integrations/pytest_plugin.py
@@ -190,9 +190,9 @@ def ragaliq_judge(request: Any, ragaliq_trace_collector: TraceCollector) -> LLMJ
             return judge
         case "openai":
             raise NotImplementedError(
-                "The OpenAI judge is not yet available in v0.1.0. "
+                "The OpenAI judge is not implemented. "
                 "Use --ragaliq-judge claude with an ANTHROPIC_API_KEY instead. "
-                "Track OpenAI support at: https://github.com/dariero/RagaliQ/issues"
+                "Track OpenAI support at: https://github.com/dariero/RagaliQ/issues/114"
             )
         case _:
             raise ValueError(f"Unknown judge type: {judge_type}")

--- a/tests/unit/test_runner.py
+++ b/tests/unit/test_runner.py
@@ -131,7 +131,7 @@ class TestJudgeTypeHandling:
         """OpenAI judge raises NotImplementedError."""
         runner = RagaliQ(judge="openai")
 
-        with pytest.raises(NotImplementedError, match="OpenAI judge is not yet available"):
+        with pytest.raises(NotImplementedError, match="OpenAI judge is not implemented"):
             runner._init_judge()
 
     def test_invalid_judge_type_raises(self):


### PR DESCRIPTION
Closes #115

`pyproject.toml:58` declared `openai = ["openai>=2.45"]` for a provider with **no implementation** — no openai judge module, `import openai` nowhere. Installing `ragaliq[openai]` pulled a package no line of code touches.

## Changes

- Extra removed.
- Both error strings said *"not yet available in **v0.1.0**"* while the package is 0.2.0 (`core/runner.py:102`, `integrations/pytest_plugin.py:193`). Replaced with version-free wording so they cannot go stale again, and pointed the tracking URL at #114 rather than the bare issue list.
- `tests/unit/test_runner.py:134` matched the old wording and **correctly failed** — updated.

## Verification

The lock is **unchanged** — openai was never in it, which is exactly what `check_floors_against_lock` had been reporting. That check now shows one absent declaration instead of two:

```
NOT IN LOCK  extra:docs  mkdocs-material>=9.7  (never exercised by ci.yml)
[+] Declared dependencies present in pylock.toml: PASS (14/15 locked, 1 absent)
```

```
lint exit=0   typecheck exit=0   test exit=0 (657 passed, 1 skipped, 3 deselected)
```

## Follow-up

**#114** — a real OpenAI transport, framed as cross-provider meta-evaluation capability. Dropping the extra does not drop that option: `JudgeTransport` is already a `Protocol` and `BaseJudge` depends on it rather than a concrete class, so an `OpenAITransport` needs no change to `BaseJudge`. The extra was never what preserved the option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)