### PR TITLE
[FIX #117] Strip the v prefix from the release body's docker pull

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,6 +193,13 @@ jobs:
           name: dist
           path: dist/
 
+      # metadata-action publishes {{version}} (0.2.0), {{major}}.{{minor}} (0.2)
+      # and latest — none of them v-prefixed. The tag ref is v0.2.0, so the
+      # release body must strip the v or it advertises a tag that 404s.
+      - name: Derive the published image tag
+        id: imgtag
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3.0.2
         with:
@@ -207,7 +214,7 @@ jobs:
 
             Docker image:
             ```bash
-            docker pull ghcr.io/dariero/ragaliq:${{ github.ref_name }}
+            docker pull ghcr.io/dariero/ragaliq:${{ steps.imgtag.outputs.version }}
             ```
 
             Full changelog: [CHANGELOG.md](https://github.com/dariero/RagaliQ/blob/main/CHANGELOG.md)


### PR DESCRIPTION
Closes #117

`release.yml` advertised `docker pull ghcr.io/dariero/ragaliq:${{ github.ref_name }}` → **`:v0.2.0`**, a tag that is never published. `metadata-action` (`:158-161`) emits `{{version}}`, `{{major}}.{{minor}}` and `latest` — per the action's own README, `v1.2.3` + `{{version}}` → `1.2.3`. Published tags are **`0.2.0`, `0.2`, `latest`**. Every release's copy-paste Docker line 404'd.

## Fix

A step that strips the prefix, referenced from the body:

```yaml
- name: Derive the published image tag
  id: imgtag
  run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
```

Verified: `v0.2.0` → `0.2.0`.

**Not** done: publishing a fourth `v`-prefixed tag to make the string true. That would add a permanent duplicate image tag to every release to fix a typo in prose.

**Left alone:** the adjacent `pip install ragaliq==${{ github.ref_name }}` at `:212`. PEP 440 permits a leading `v` and normalises it away, so it resolves correctly — flagged explicitly so a future reader does not "fix" a non-bug while fixing the line above it.

## Verification

YAML re-parsed; gates green. **`release.yml` cannot be exercised without pushing a tag**, so this is verified by the strip logic and the action's documented semantics, not by a run. Stating that rather than implying otherwise.

```
lint exit=0   typecheck exit=0   test exit=0 (657 passed)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)