### PR TITLE
[DOCS #119] Replace the stale dependency block with the transport seam

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -275,33 +275,50 @@ ragaliq/
 
 ---
 
-## Dependencies
+## Dependencies and the provider seam
 
-*Note: For current dependency versions, see `pyproject.toml` as the single source of truth.*
+`pyproject.toml` is the single source of truth for versions. This section
+deliberately does **not** restate them: a copy here drifted to seven wrong
+floors and a dependency that never existed (`httpx`), which is exactly the
+duplicated-fact problem the consistency checks in `scripts/verify_release.py`
+now guard against elsewhere.
 
-```toml
-[project]
-dependencies = [
-    "anthropic>=0.40.0",
-    "openai>=1.50.0",
-    "pydantic>=2.0",
-    "typer>=0.12.0",
-    "rich>=13.0",
-    "jinja2>=3.1",
-    "pyyaml>=6.0",
-    "httpx>=0.27",
-    "tenacity>=8.0",
-]
+What is worth describing here is the shape the dependencies serve.
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=8.0",
-    "pytest-asyncio>=0.23",
-    "pytest-cov>=4.0",
-    "ruff>=0.4",
-    "mypy>=1.10",
-]
-```
+### The transport seam
+
+Provider access is isolated behind one structural type, so swapping or adding
+a provider does not touch judging logic. See
+[`ADR-000-judge-transport-protocol.md`](../.decisions/ADR-000-judge-transport-protocol.md).
+
+- **`JudgeTransport`** (`judges/transport.py`) is a `Protocol`, not a base
+  class. Anything with a matching `send()` satisfies it — no registration, no
+  inheritance.
+- **`ClaudeTransport`** implements it by wrapping `AsyncAnthropic`. It owns
+  provider HTTP calls, retries and token counting, and nothing else.
+- **`BaseJudge`** depends on the protocol rather than any concrete transport.
+  Prompt building, response parsing and score clamping live there, so they are
+  written once and shared by every provider.
+
+Because the dependency points at a structural type, adding a second provider
+is additive: an `OpenAITransport` with a matching `send()` requires no change
+to `BaseJudge`. That is what preserves cross-provider optionality — not a
+declared extra. Tracked in #114.
+
+### Direct runtime dependencies, by role
+
+| Package | Role |
+|---|---|
+| `anthropic` | the only provider SDK currently wired, used solely by `ClaudeTransport` |
+| `pydantic` | every data structure; strict validation at the boundaries |
+| `tenacity` | retry policy around transport calls |
+| `typer` | CLI |
+| `rich` | terminal rendering |
+| `jinja2` | HTML report templates |
+| `pyyaml` | dataset and prompt loading |
+
+`httpx` is **not** a RagaliQ dependency. It appears in `pylock.toml` only as
+anthropic's transitive pull, and is imported nowhere in the project.
 
 ---
 


### PR DESCRIPTION
Closes #119

`docs/PROJECT_PLAN.md` reproduced a `[project]` dependency block that had drifted on **every single line**:

| listed | actual |
|---|---|
| `anthropic>=0.40.0` | `>=0.120` |
| `openai>=1.50.0` | extra removed in #116 |
| `pydantic>=2.0` | `>=2.13` |
| `typer>=0.12.0` | `>=0.27` |
| `rich>=13.0` | `>=15` |
| `tenacity>=8.0` | `>=9.1` |
| **`httpx>=0.27`** | **not a dependency, and never was** |

The dev list was equally stale (`pytest>=8.0`, `ruff>=0.4`, `mypy>=1.10`).

`httpx` is imported nowhere in `src/`, `tests/`, `demos/`, `examples/` or `scripts/`; it reaches `pylock.toml` only as anthropic's transitive pull. The doc asserted it was part of the stack and the code never supported that.

## The underlying problem

The block duplicated a fact `pyproject.toml` already owns — while its own preamble called pyproject the single source of truth. It contradicted itself. Restating the versions correctly would just reset the clock on the same drift.

## What replaced it

The architecture the section should have been describing, cross-referencing [`ADR-000-judge-transport-protocol.md`](../.decisions/ADR-000-judge-transport-protocol.md):

- `JudgeTransport` is a **`Protocol`**, not a base class — anything with a matching `send()` satisfies it, no registration or inheritance.
- `ClaudeTransport` implements it by wrapping `AsyncAnthropic`, owning provider HTTP, retries and token counting and nothing else.
- `BaseJudge` depends on the protocol rather than a concrete transport, so prompt building, parsing and clamping are written once.

Which makes the #114 point concrete: adding `OpenAITransport` requires no change to `BaseJudge`. **The structural type is what preserved cross-provider optionality — not the declared extra that #116 removed.**

Dependencies are now listed **by role, not by version**, so the section cannot go stale on a bump.

```
lint exit=0   typecheck exit=0   test exit=0 (657 passed)
```

ADR-000 link verified to resolve. `PROJECT_PLAN.md` is not in the mkdocs nav, so the docs build is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)