### PR TITLE
[FIX #121] Start coverage before pytest so Codecov gets the real number

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,9 +104,18 @@ jobs:
           uv pip sync pylock.toml
           uv pip install -e . --no-deps
 
+      # coverage run -m pytest, NOT pytest --cov: the pytest11 entry point loads
+      # the plugin (and everything it imports at module scope) before pytest-cov
+      # starts measuring, so those lines are miscounted as never executed. That
+      # understated the figure fed to Codecov by 22 points - 69% against a real
+      # 91%, 478 missed statements against 103. -o addopts="" drops the inherited
+      # --cov flags so the two mechanisms do not fight.
       - name: Run unit tests
-        # --cov-report=xml writes coverage.xml for the Codecov upload below.
-        run: .venv/bin/pytest tests/unit/ tests/meta/test_meta_metrics.py --cov-report=xml
+        run: |
+          .venv/bin/coverage run --source=src/ragaliq -m pytest \
+            tests/unit/ tests/meta/test_meta_metrics.py -o addopts="" -q
+          .venv/bin/coverage report
+          .venv/bin/coverage xml -o coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v7.0.0


### PR DESCRIPTION
Closes #121

The `pytest11` entry point loads `ragaliq.integrations.pytest_plugin` — and everything it imports at module scope — **before** pytest-cov starts measuring. Those lines were counted as never executed.

## Measured, same suite, same tests

| mechanism | statements | missed | reported |
|---|---|---|---|
| `pytest --cov` (what `ci.yml` ran) | 1384 | **478** | **69%** |
| `coverage run -m pytest` | 1384 | **103** | **91%** |

**375 statements, 22 percentage points.** Per-file, from `coverage.xml`:

| file | before | after |
|---|---|---|
| `integrations/__init__.py` | 0% | **100%** |
| `integrations/github_actions.py` | 84% | **100%** |
| `integrations/pytest_plugin.py` | 55% | **71%** |

`ci.yml` fed the 69% to Codecov, so the badge and every trend line understated coverage — the direction that quietly trains people to stop trusting the metric.

## Fix

```yaml
.venv/bin/coverage run --source=src/ragaliq -m pytest \
  tests/unit/ tests/meta/test_meta_metrics.py -o addopts="" -q
.venv/bin/coverage report
.venv/bin/coverage xml -o coverage.xml
```

`-o addopts=""` drops the inherited `--cov` flags so the two mechanisms do not fight — without it pytest-cov starts a second, late-starting measurement inside the outer coverage process.

## Verification

Ran the exact CI command locally: **626 passed, 1384 statements, 103 missed, 91%**. Generated `coverage.xml` and confirmed the Codecov payload — overall line-rate **0.9256**, with the three integrations files at 1.0, 1.0 and 0.7143.

```
lint exit=0   typecheck exit=0   test exit=0 (657 passed)
```

The local `hatch run test` still reports 69% — it uses `pytest --cov` via `addopts`. Only the CI path changed here; aligning the local gate is a separate call, since the `--cov` default is convenient interactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)