### PR TITLE
[CHORE #123] Grouped Dependabot, floor policy, quarterly pre-commit step

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+version: 2
+
+# Grouping is deliberate. Ungrouped, Dependabot opens one PR per dependency per
+# week; the volume trains you to merge without reading, which is worse than a
+# stale pin. Grouping trades per-dependency bisectability for a review that
+# actually happens.
+#
+# The pip groups mirror the slice discipline the manual bumps used: a ruff bump
+# rewrites formatting across the tree, and mixing that with a runtime bump makes
+# the diff unreviewable. Keeping tooling and runtime apart preserves that.
+#
+# NOT covered here:
+#   - pyproject floors. Dependabot proposes lock/pin updates; floors move only
+#     when a feature requires it or support is deliberately dropped. See the
+#     dependency policy in CLAUDE.md.
+#   - pre-commit revs. No Dependabot ecosystem reaches them — CONTRIBUTING.md
+#     carries a quarterly `pre-commit autoupdate` step instead.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "[CHORE]"
+    groups:
+      actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "[CHORE]"
+    groups:
+      # A ruff major produces a whole-tree lint/format diff. It must never share
+      # a PR with a runtime bump.
+      tooling:
+        patterns:
+          - ruff
+          - mypy
+          - pytest*
+          - types-*
+          - pre-commit
+      runtime:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - ruff
+          - mypy
+          - pytest*
+          - types-*
+          - pre-commit
+
+  - package-ecosystem: docker
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: "[CHORE]"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,28 @@
 - Use `ruff` for linting and formatting -- no manual style overrides
 </constraints>
 
+## Dependency Policy
+
+**Floors move for a reason, never because something newer exists.**
+
+A `>=` floor in `pyproject.toml` is a support claim: the oldest version the code
+is known to work with. Raise it only when
+
+1. a feature the code now uses requires it, or
+2. support for older versions is being deliberately dropped.
+
+"A newer release exists" is not a reason. Dependabot proposes lock and pin
+updates; it is not wired to floors.
+
+**A floor bump with no lock regeneration changes nothing about what CI runs.**
+CI installs with `uv pip sync pylock.toml` then `uv pip install -e . --no-deps`,
+so the floors are never resolved — the lock is the only thing exercised. Bump a
+floor without regenerating, and the PR is green and inert.
+
+Regenerate one package at a time and diff the lock before committing; see
+CONTRIBUTING.md. `scripts/verify_release.py --consistency-only` asserts the
+floors, the pins and the lock still agree.
+
 ## Design Decisions (MUST follow in all new code)
 
 1. **Evaluator Pattern**: Each metric MUST be a separate Evaluator class with `evaluate()` method. DO NOT refactor to alternative patterns without explicit approval.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,6 +45,26 @@ hatch run check
 > A platform-specific lock (e.g. from `hatch dep lock` on macOS) breaks Linux CI,
 > so the lock must be `--universal`. CI installs strictly from this lock via uv.
 
+## Keeping pre-commit revs current
+
+Dependabot has no ecosystem that reaches `.pre-commit-config.yaml`. Run
+**`pre-commit autoupdate` quarterly** and review the diff before staging;
+`git checkout -- .pre-commit-config.yaml` reverts it.
+
+> **ruff lives in three places and they move together:** the `dev` extra floor
+> in `pyproject.toml`, the `rev:` in `.pre-commit-config.yaml`, and the pin in
+> `pylock.toml`. `autoupdate` moves only the second. Left split, the pre-commit
+> hook and `hatch run lint` format the same tree differently.
+>
+> A split does not even need `autoupdate`: the floor is a `>=`, so a fresh
+> `hatch env` resolve alone pulls a newer ruff than the pinned hook. Run
+> `python scripts/verify_release.py --consistency-only` after any of the three
+> changes — `check_ruff_atom` fails if they disagree.
+
+The `additional_dependencies` under `mirrors-mypy` are a further copy of the
+runtime floors. If they lag, mypy types against a different version than the
+code imports.
+
 ## Code Standards
 
 - **Type hints** are required on all public functions and methods.


### PR DESCRIPTION
Closes #123

Five slices of manual version work (#101, #106, #111, #113, #116) turned up five stale action pins and four stale packages. That sweep should not be a person's job.

## `.github/dependabot.yml`

| ecosystem | schedule | grouping |
|---|---|---|
| `github-actions` | weekly | one grouped PR |
| `pip` | weekly | two groups — `tooling` and `runtime` |
| `docker` | monthly | — |

The pip split mirrors the discipline that made the manual bumps reviewable: a ruff bump rewrites formatting across the tree, and mixed with a runtime bump the diff is unreadable. `tooling` is ruff, mypy, pytest\*, types-\*, pre-commit; `runtime` is everything else via `exclude-patterns`.

### The cost, named

**Ungrouped, Dependabot opens one PR per dependency per week, and the volume trains you to merge without reading** — which is worse than a stale pin, because it looks like diligence. Grouping trades per-dependency bisectability for a review that actually happens. If a grouped PR ever breaks something, bisecting inside it is manual; that is the accepted price.

## Floor policy in `CLAUDE.md`

A  floor is a **support claim** — the oldest version the code is known to work with — not a changelog. It moves when a feature requires it or when support is deliberately dropped. "A newer release exists" is not a reason, and Dependabot is deliberately not wired to floors.

Also recorded, because it is the non-obvious half: **a floor bump with no lock regeneration is inert.** CI runs `uv pip sync pylock.toml` then `uv pip install -e . --no-deps`, so floors are never resolved — the PR goes green having changed nothing about what was tested.

## Quarterly pre-commit step in `CONTRIBUTING.md`

No Dependabot ecosystem reaches `.pre-commit-config.yaml`, so it stays manual. The note spells out the trap: **ruff lives in three places that move together** (dev floor, `rev:`, lock pin) and `autoupdate` moves only the second. And that a split needs no `autoupdate` at all — the floor is a `>=`, so a fresh `hatch env` resolve alone pulls a newer ruff than the pinned hook. `--consistency-only` catches it either way.

## Gates

```
lint exit=0   typecheck exit=0   test exit=0 (657 passed)   consistency exit=0
```

`dependabot.yml` parsed; ecosystems confirmed as `github-actions`, `pip`, `docker`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)