### PR TITLE
[FIX #125] Reference ADR-000 by URL so the strict docs build passes

### DIFF
--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -289,7 +289,7 @@ What is worth describing here is the shape the dependencies serve.
 
 Provider access is isolated behind one structural type, so swapping or adding
 a provider does not touch judging logic. See
-[`ADR-000-judge-transport-protocol.md`](../.decisions/ADR-000-judge-transport-protocol.md).
+[`ADR-000-judge-transport-protocol.md`](https://github.com/dariero/RagaliQ/blob/main/.decisions/ADR-000-judge-transport-protocol.md).
 
 - **`JudgeTransport`** (`judges/transport.py`) is a `Protocol`, not a base
   class. Anything with a matching `send()` satisfies it — no registration, no


### PR DESCRIPTION
Closes #125

**I broke this in #120.** The link added there — `../.decisions/ADR-000-judge-transport-protocol.md` — points outside the mkdocs docs directory:

```
WARNING - Doc file 'PROJECT_PLAN.md' contains a link
          '../.decisions/ADR-000-judge-transport-protocol.md',
          but the target is not found among documentation files.
Aborted with 1 warnings in strict mode!
```

Docs has been red on main since `1471410`.

## The check I got wrong

Before merging #120 I confirmed `PROJECT_PLAN.md` is absent from the mkdocs nav and concluded the docs build was unaffected. **That inference is invalid**: mkdocs builds pages outside the nav (it says so, as an INFO line), and `--strict` still fails on their broken links. Absence from nav is not exclusion from the build. The only sound check was running the build, which I have now done.

## Fix

Absolute GitHub URL — resolves for readers, exempt from the internal-link check. Verified in a clean venv against `.[docs]`:

```
mkdocs build --strict   exit=0
'Aborted with' occurrences: 0
```

Also removes a stray empty `=` file that a shell redirect typo created and `git add -A` swept into the first commit. Squash-merge collapses both commits, so it never reaches main.

```
lint exit=0   typecheck exit=0   test exit=0 (657 passed)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)