### PR TITLE
[FIX #127] Gate docs on PRs and make a red meta-eval reach somebody

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,13 @@
 name: Docs
 
 # Deploys the MkDocs site to GitHub Pages on every push to main.
-# Also triggerable manually via the Actions tab.
+# Also builds (without deploying) on pull requests: mkdocs runs --strict, so a
+# broken link fails the build. Without the pull_request trigger that check only
+# ran after merge, which is how #120 landed green and broke main until #126.
 on:
   push:
+    branches: [main]
+  pull_request:
     branches: [main]
   workflow_dispatch:
 
@@ -13,10 +17,15 @@ permissions:
   pages: write
   id-token: write
 
-# Do NOT cancel in-progress deployments — a partial deploy leaves the site broken.
+# Deployments share one group and are never cancelled — a partial deploy leaves
+# the site broken. PR builds get their own per-ref group so they neither queue
+# behind a deploy nor block one, and superseded PR builds are cancellable.
 concurrency:
-  group: pages
-  cancel-in-progress: false
+  group: >-
+    ${{ github.event_name == 'pull_request'
+        && format('docs-pr-{0}', github.ref)
+        || 'pages' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:
@@ -37,7 +46,10 @@ jobs:
         # --strict turns warnings into errors so broken links don't ship silently.
         run: mkdocs build --strict
 
+      # Only the deploying runs need an artifact; on a PR the --strict build
+      # above is the whole point.
       - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
         uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: site/
@@ -45,6 +57,7 @@ jobs:
   deploy:
     name: Deploy to GitHub Pages
     needs: build
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/.github/workflows/meta-eval.yml
+++ b/.github/workflows/meta-eval.yml
@@ -20,6 +20,7 @@ concurrency:
 
 permissions:
   contents: read
+  issues: write  # the failure reporter opens/comments on a tracking issue
 
 jobs:
   meta-eval:
@@ -51,6 +52,32 @@ jobs:
           RAGALIQ_RUN_META: "1"
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         run: .venv/bin/pytest tests/meta/ -m meta --no-cov -v -s
+
+      # A weekly job that fails on nobody's PR notifies nobody by default:
+      # GitHub emails only this file's last committer, which is easy to filter
+      # away. Deduplicated on purpose — a fresh issue every week is noise, and
+      # noise is how a red gate starts reading as green.
+      - name: Report failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          existing=$(gh issue list --label meta-eval-failure --state open \
+            --limit 1 --json number --jq '.[0].number // empty')
+          if [ -n "$existing" ]; then
+            gh issue comment "$existing" --body "Failed again: $RUN_URL"
+          else
+            gh issue create \
+              --title "[FIX] Scheduled meta-eval failed" \
+              --label bug,testing,meta-eval-failure \
+              --body "Run: $RUN_URL
+
+          The weekly judge-agreement gate failed. Check the drift delta against the
+          baseline pinned in #89 before assuming a judge regression - #102 was a
+          fixture defect, not the judge. An auth failure looks the same from here:
+          confirm ANTHROPIC_API_KEY is valid before investigating scores."
+          fi
 
       # Runs on failure too — a regression is exactly when the numbers matter.
       - name: Write agreement numbers to step summary


### PR DESCRIPTION
Closes #127. Closes the #94 follow-up.

Two instances of the same defect class this sequence has been eliminating: **a check that cannot stop the thing it checks.**

## 1. `docs.yml` was not a PR gate

It triggered on `push: branches: [main]` and `workflow_dispatch` **only**. That is precisely why #120 merged green, broke the `--strict` docs build, and needed #126 to repair main. A post-merge check is an alarm, not a gate.

Added `pull_request`, building **without deploying**:
- `Upload Pages artifact` and the whole `deploy` job are skipped when `github.event_name == 'pull_request'`.
- PR builds get a per-ref concurrency group, so they neither queue behind a deployment nor block one; deploys keep the single `pages` group with `cancel-in-progress: false`, since a partial deploy leaves the site broken.

**This PR is its own test** — the Docs check appearing here is the fix working.

## 2. A red meta-eval reached nobody

`meta-eval.yml` runs weekly and blocks no PR; GitHub emails only the workflow file's last committer, which is easy to filter away. A weekly job failing silently for a month reads as *"the gate is green"* — the same failure `pytest.fail` was added in #93 to prevent.

A `failure()` step now opens a tracking issue, or **comments on the existing one** if `meta-eval-failure` is already open. Deduplication is the point: a fresh issue every week is noise, and noise is how a red gate starts reading as green.

The body points at the #89 baseline and flags that **#102 was a fixture defect, not a judge regression** — and that an auth failure looks identical from the outside, which is the likely first failure after a key rotation.

Requires `permissions: issues: write`. Label `meta-eval-failure` created.

## Verification, no paid dispatch

```
both workflows parse           jobs: docs [build, deploy], meta-eval [meta-eval]
reporter script  bash -n       syntax OK
lint 0   typecheck 0   test 0 (657 passed)   consistency 0
```

The reporter is **not** exercised here — triggering it would mean failing a ~43-call paid run to test an issue-creation step. The next scheduled run exercises it for free if it fails, and does nothing if it passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)